### PR TITLE
Add standalone Privacy Policy and Terms of Service pages

### DIFF
--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,0 +1,124 @@
+---
+layout: layouts/archive.njk
+permalink: /privacy/
+eleventyExcludeFromCollections: true
+title: Privacy Policy
+description: Jonny McConnell's privacy policy explaining how we collect, use, disclose, and protect information.
+---
+
+# Privacy Policy
+
+**Effective Date:** June 09, 2026
+
+**Last Updated:** June 09, 2026
+
+**Jonmccon** ("we," "our," "us") respects your privacy. This Privacy Policy explains how we collect, use, disclose, and protect information when you use **jonmccon.com**, **cloudpaul**, and related services (collectively, the "Services").
+
+## 1) CONTACT INFORMATION
+
+If you have questions about this Privacy Policy, contact us at:
+
+- **Company:** Jonathan McConnell
+- **Email:** Jonmccon@gmail.com
+- **Address:** [MAILING ADDRESS]
+
+## 2) INFORMATION WE COLLECT
+
+We may collect:
+
+- nothing
+
+## 3) HOW WE COLLECT INFORMATION
+
+We collect information:
+
+- everything is private to your server
+
+## 4) HOW WE USE INFORMATION
+
+We use information to:
+
+- we can't see anything
+
+## 5) GOOGLE OAUTH AND GOOGLE USER DATA
+
+If you sign in with Google, we access only the data and scopes you authorize.
+
+Google user data is used only to:
+
+- Authenticate your account.
+- Provide features you explicitly request.
+- Maintain and secure your account/session.
+
+We do not sell Google user data.
+
+We do not use Google user data for advertising.
+
+We do not transfer Google user data to third parties except:
+
+- As necessary to provide or secure the Services.
+- To comply with applicable law.
+- With your explicit consent.
+
+If your app requests sensitive or restricted Google scopes, add an exact scope list and purpose here:
+
+- https://www.googleapis.com/auth/docs
+- https://www.googleapis.com/auth/drive in order to be able to edit, create and delete files with RClone.
+- https://www.googleapis.com/auth/drive.metadata.readonly which you may also want to add.
+
+Docs available here https://rclone.org/drive/#making-your-own-client-id
+
+## 6) LEGAL BASES (EEA/UK, IF APPLICABLE)
+
+Where required, we process personal data under these legal bases:
+
+- Contract performance.
+- Legitimate interests.
+- Consent.
+- Legal obligation.
+
+## 7) COOKIES AND TRACKING
+
+You can control cookies through your browser settings.
+
+## 8) SHARING OF INFORMATION
+
+We may share information with:
+
+- we don't
+
+## 9) DATA RETENTION
+
+- nothing is logged
+
+## 10) DATA SECURITY
+
+We use reasonable administrative, technical, and organizational measures to protect personal data. No method of transmission or storage is 100% secure.
+
+## 11) YOUR RIGHTS
+
+Depending on your location, you may have rights to:
+
+- Access, correct, or delete your personal data.
+- Object to or restrict processing.
+- Data portability.
+- Withdraw consent where processing is based on consent.
+- Lodge a complaint with a supervisory authority.
+
+To exercise rights, contact: [PRIVACY CONTACT EMAIL]
+
+## 12) INTERNATIONAL DATA TRANSFERS
+
+Your information may be processed in countries other than your own. Where required, we use appropriate safeguards.
+
+## 13) CHILDREN'S PRIVACY
+
+The Services are not directed to children under 13. We do not knowingly collect personal data from children.
+
+## 14) THIRD-PARTY LINKS/SERVICES
+
+The Services may link to third-party sites or services. We are not responsible for their privacy practices.
+
+## 15) CHANGES TO THIS PRIVACY POLICY
+
+We may update this Privacy Policy from time to time. We will post the updated version with a revised "Last Updated" date.

--- a/content/terms.md
+++ b/content/terms.md
@@ -1,0 +1,108 @@
+---
+layout: layouts/archive.njk
+permalink: /terms/
+eleventyExcludeFromCollections: true
+title: Terms of Service
+description: Jonny McConnell's terms of service governing use of jonmccon.com, cloudpaul, and related services.
+---
+
+# Terms of Service
+
+**Effective Date:** June 09, 2026
+
+**Last Updated:** June 09, 2026
+
+These Terms of Service ("Terms") govern your use of **jonmccon.com**, **cloudpaul**, and related services (collectively, the "Services"), provided by **Jonathan McConnell** ("we," "our," "us").
+
+By accessing or using the Services, you agree to these Terms. If you do not agree, do not use the Services.
+
+## 1) ELIGIBILITY
+
+You must be at least **18 OR APPLICABLE AGE** and able to enter a binding contract to use the Services.
+
+## 2) ACCOUNTS
+
+You may need an account to use certain features.
+
+You agree to:
+
+- Provide accurate information.
+- Keep your credentials confidential.
+- Notify us promptly of unauthorized access at [SUPPORT EMAIL].
+
+You are responsible for activity under your account.
+
+## 3) GOOGLE SIGN-IN
+
+If you use Google OAuth to access the Services, you authorize us to receive and use data you approve via Google permissions.
+
+Your use of Google services is also subject to Google's terms and privacy policies.
+
+## 4) ACCEPTABLE USE
+
+You agree not to:
+
+- Violate laws or regulations.
+- Infringe intellectual property or privacy rights.
+- Interfere with or disrupt the Services.
+- Attempt unauthorized access to systems or data.
+- Upload malware or harmful code.
+- Use automated means to scrape or abuse the Services without permission.
+
+## 5) USER CONTENT
+
+If you submit or upload content, you retain ownership of your content.
+
+You represent that you have all rights necessary to submit such content.
+
+## 6) FEES AND PAYMENTS (IF APPLICABLE)
+
+The Services are currently provided free of charge.
+
+## 7) INTELLECTUAL PROPERTY
+
+The Services, including software, trademarks, logos, and content (excluding user content), are owned by **Jonathan McConnell** or licensors and are protected by law.
+
+No rights are granted except as expressly stated in these Terms.
+
+## 8) THIRD-PARTY SERVICES
+
+The Services may integrate with third-party services. We are not responsible for third-party services and do not guarantee their availability or accuracy.
+
+## 9) DISCLAIMER OF WARRANTIES
+
+THE SERVICES ARE PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT, TO THE MAXIMUM EXTENT PERMITTED BY LAW.
+
+## 10) LIMITATION OF LIABILITY
+
+TO THE MAXIMUM EXTENT PERMITTED BY LAW, **Jonathan McConnell** WILL NOT BE LIABLE FOR INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, EXEMPLARY, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS, REVENUE, DATA, OR GOODWILL.
+
+OUR TOTAL LIABILITY FOR ANY CLAIMS ARISING OUT OF OR RELATED TO THE SERVICES WILL NOT EXCEED $1
+
+## 11) INDEMNIFICATION
+
+You agree to defend, indemnify, and hold harmless **Jonathan McConnell** and its affiliates, officers, directors, employees, and agents from claims, damages, liabilities, and expenses arising out of your use of the Services, your content, or your violation of these Terms.
+
+## 12) TERMINATION
+
+We may suspend or terminate access to the Services at any time, with or without notice, including for violation of these Terms.
+
+You may stop using the Services at any time.
+
+## 13) GOVERNING LAW AND DISPUTES
+
+These Terms are governed by the laws of **WA/USA**, without regard to conflict of law rules.
+
+Any dispute will be resolved in the courts located in **WA**, unless otherwise required by law.
+
+## 14) CHANGES TO TERMS
+
+We may modify these Terms from time to time. Continued use after updates means you accept the revised Terms.
+
+## 15) CONTACT
+
+Questions about these Terms:
+
+- **Company:** Jonathan McConnell
+- **Email:** Jonmccon@gmail.com
+- **Address:** [MAILING ADDRESS]


### PR DESCRIPTION
- content/privacy.md: Privacy Policy page at /privacy/
- content/terms.md: Terms of Service page at /terms/

Both pages use layouts/archive.njk with eleventyExcludeFromCollections: true Content pulled from live jonmccon.com/privacy and jonmccon.com/terms