### PR TITLE
feat: homepage structure v2 — compact axis hero, dot markers, featured grid, podcast card

### DIFF
--- a/_includes/homeFeaturedProjects.njk
+++ b/_includes/homeFeaturedProjects.njk
@@ -1,0 +1,24 @@
+{% set featuredPosts = collections.semiFeaturedProjects %}
+{% if featuredPosts and featuredPosts.length %}
+<section class="home-featured-grid" aria-label="Featured work">
+  {% for post in featuredPosts | reverse %}
+  <a href="{{ post.url }}" class="home-featured-card">
+    <div class="home-featured-thumb">
+      {% if post.data.thumbnail %}
+        <img src="{{ post.data.thumbnail }}" alt="{{ post.data.title }}" loading="lazy" width="400" height="300">
+      {% elif post.data.images and post.data.images.length %}
+        {% homepageImage post.data.images[0].src, post.data.title, 400, "home-featured-img" %}
+      {% else %}
+        <div class="home-featured-placeholder">
+          <span class="home-featured-placeholder-label">Case study coming soon</span>
+        </div>
+      {% endif %}
+    </div>
+    <div class="home-featured-meta">
+      <span class="home-featured-title">{{ post.data.title }}</span>
+      {% if post.data.description %}<span class="home-featured-tagline">{{ post.data.description }}</span>{% endif %}
+    </div>
+  </a>
+  {% endfor %}
+</section>
+{% endif %}

--- a/_includes/homeFeaturedProjects.njk
+++ b/_includes/homeFeaturedProjects.njk
@@ -1,23 +1,27 @@
 {% set featuredPosts = collections.semiFeaturedProjects %}
+{% if not featuredPosts or not featuredPosts.length %}
+  {% set featuredPosts = collections.featuredProjects %}
+{% endif %}
 {% if featuredPosts and featuredPosts.length %}
 <section class="home-featured-grid" aria-label="Featured work">
   {% for post in featuredPosts | reverse %}
-  <a href="{{ post.url }}" class="home-featured-card">
-    <div class="home-featured-thumb">
-      {% if post.data.thumbnail %}
-        <img src="{{ post.data.thumbnail }}" alt="{{ post.data.title }}" loading="lazy" width="400" height="300">
-      {% elif post.data.images and post.data.images.length %}
-        {% homepageImage post.data.images[0].src, post.data.title, 400, "home-featured-img" %}
-      {% else %}
-        <div class="home-featured-placeholder">
-          <span class="home-featured-placeholder-label">Case study coming soon</span>
-        </div>
+  <a href="{{ post.url }}" class="home-featured-row{% if not (post.data.images and post.data.images.length) and not post.data.thumbnail %} home-featured-row--no-media{% endif %}">
+    <span class="home-featured-row-media" aria-hidden="true">
+      {% if post.data.images and post.data.images.length %}
+        {% for image in post.data.images %}
+          {% if loop.index <= 3 %}
+          <span class="home-featured-row-media-frame">
+            {% homepageImage image.src, "", 720, "home-featured-row-media-img" %}
+          </span>
+          {% endif %}
+        {% endfor %}
+      {% elif post.data.thumbnail %}
+        <span class="home-featured-row-media-frame">
+          <img src="{{ post.data.thumbnail }}" alt="" loading="lazy" width="1200" height="320" class="home-featured-row-media-img">
+        </span>
       {% endif %}
-    </div>
-    <div class="home-featured-meta">
-      <span class="home-featured-title">{{ post.data.title }}</span>
-      {% if post.data.description %}<span class="home-featured-tagline">{{ post.data.description }}</span>{% endif %}
-    </div>
+    </span>
+    <span class="home-featured-row-title">{{ post.data.title }}</span>
   </a>
   {% endfor %}
 </section>

--- a/_includes/homeFeaturedProjects.njk
+++ b/_includes/homeFeaturedProjects.njk
@@ -21,7 +21,7 @@
         </span>
       {% endif %}
     </span>
-    <span class="home-featured-row-title">{{ post.data.title }}</span>
+    <h2 class="home-featured-row-title">{{ post.data.title }}</h2>
   </a>
   {% endfor %}
 </section>

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -32,27 +32,19 @@ layout: layouts/base.njk
     </div>
 
     {% for post in collections.featuredProjects | reverse %}
-    {% if loop.index <= featuredProjectThumbnailLimit and post.data.images and post.data.images.length %}
+    {% if loop.index <= featuredProjectThumbnailLimit %}
     <article class="home-axis-project" data-axis-project data-project-index="{{ loop.index0 }}" data-project-title="{{ post.data.title | slugify }}" data-project-tags="{{ (post.data.tags | filterTagList | join(',')) | lower }}">
       <a class="home-axis-project-link" href="{{ post.url }}" aria-label="{{ post.data.title }}">
-        <div class="home-axis-pile" data-image-count="{{ post.data.images.length }}">
-          {% for img in post.data.images | head(4) %}
-          <div class="home-axis-pile-image" data-layer-index="{{ loop.index0 }}" style="--z-index: {{ 10 - loop.index0 }};">
-            {% homepageImage img.src, img.alt | default(post.data.title), 360, "home-axis-pile-img" %}
-          </div>
-          {% endfor %}
+        <div class="home-axis-dot">
+          {% if post.data.images and post.data.images.length %}
+            {% homepageImage post.data.images[0].src, post.data.title, 80, "home-axis-dot-img" %}
+          {% endif %}
         </div>
         <span class="home-axis-project-title">{{ post.data.title }}</span>
       </a>
     </article>
     {% endif %}
     {% endfor %}
-    <div class="home-see-all-link">
-      <a href="/design/">
-        <span>See all work</span>
-        <span aria-hidden="true">→</span>
-      </a>
-    </div>
   </div>
 </section>
 
@@ -60,27 +52,35 @@ layout: layouts/base.njk
   {% if introductionText %}
   <p class="homepage-about">{{ introductionText }}</p>
   {% endif %}
-  <section class="home-supporting-media" aria-label="Podcast appearances and tools">
-    <div class="home-supporting-media-grid">
-      <article class="home-supporting-media-card">
-        <h2 class="home-supporting-media-title">Podcasts</h2>
-        <p class="home-supporting-media-text">Recent conversations on design systems, product strategy, and building thoughtful tools.</p>
-        <iframe class="home-supporting-player" height="200" width="100%" frameborder="no" scrolling="no" seamless src="https://player.simplecast.com/9fc38fe1-df84-4a61-8348-b4a888606182?dark=false" title="Simplecast podcast player 1"></iframe>
-        <iframe class="home-supporting-player" height="200" width="100%" frameborder="no" scrolling="no" seamless src="https://player.simplecast.com/a8c63034-9b6c-4d56-b3ed-e440f6a3e031?dark=false" title="Simplecast podcast player 2"></iframe>
-      </article>
-      <article class="home-supporting-feature" aria-label="Featured tool">
-        <div class="home-supporting-feature-image" aria-hidden="true">
-          <span class="home-supporting-feature-image-mark">TB</span>
-        </div>
-        <div class="home-supporting-feature-copy">
-          <h2 class="home-supporting-media-title">Featured Tool</h2>
-          <h3 class="home-supporting-feature-heading">Obsidian Time Blocks Plugin</h3>
-          <p class="home-supporting-feature-text">A lightweight bookmark for planning focused work in Obsidian with a simple time-blocking workflow.</p>
-          <a class="home-supporting-link" href="https://community.obsidian.md/plugins/time-blocks" target="_blank" rel="noreferrer">Open plugin page</a>
-        </div>
-      </article>
+
+  {% include "homeFeaturedProjects.njk" %}
+
+  <div class="home-cta-row">
+    <a href="/design/">See all work <span aria-hidden="true">→</span></a>
+  </div>
+
+  <section class="home-podcast-feature" aria-label="Podcast">
+    <div class="home-podcast-grid">
+      <div class="home-podcast-cover">
+        <img src="/img/podcast/scd-podcast-cover.png" alt="Seattle Creative Directory Podcast" width="300" height="300">
+      </div>
+      <div class="home-podcast-copy">
+        <h2 class="home-podcast-title">Seattle Creative Directory Podcast</h2>
+        <p class="home-podcast-desc">Conversations with Seattle's working creative community — designers, founders, makers, and the people building culture in the Pacific Northwest.</p>
+        <iframe class="home-supporting-player" height="200" width="100%" frameborder="no" scrolling="no" seamless src="https://player.simplecast.com/9fc38fe1-df84-4a61-8348-b4a888606182?dark=false" title="SCD Podcast episode 1"></iframe>
+        <iframe class="home-supporting-player" height="200" width="100%" frameborder="no" scrolling="no" seamless src="https://player.simplecast.com/a8c63034-9b6c-4d56-b3ed-e440f6a3e031?dark=false" title="SCD Podcast episode 2"></iframe>
+        <a class="home-supporting-link home-podcast-all-link" href="https://seattlecreative.directory/podcast" target="_blank" rel="noreferrer">All episodes ↗</a>
+      </div>
     </div>
   </section>
+
+  <aside class="home-aside-row">
+    <span class="home-aside-label">Also</span>
+    <a href="https://community.obsidian.md/plugins/time-blocks" target="_blank" rel="noreferrer">
+      Obsidian Time Blocks — a lightweight time-blocking plugin for focused work in Obsidian.
+    </a>
+  </aside>
+
   <div class="home-supporting-links home-supporting-links-footer" aria-label="Supporting links">
     {% for link in homeContactLinks %}
     <a class="home-supporting-link home-supporting-link-footer" href="{{ link.url }}"{% if link.external %} target="_blank" rel="noreferrer"{% endif %}>
@@ -106,39 +106,6 @@ layout: layouts/base.njk
   </div>
 </section>
 
-{% if collections.semiFeaturedProjects.length > 0 %}
-<section class="home-semi-featured-grid" aria-label="Selected work">
-  <div class="thumb-grid">
-    {% for post in collections.semiFeaturedProjects | reverse %}
-      {% if loop.index <= 6 %}
-        {% if post.data.thumbnail %}
-          <a href="{{ post.url }}" class="thumb-grid-item">
-            <img src="{{ post.data.thumbnail }}" alt="{{ post.data.title }}" loading="lazy" decoding="async" width="300" height="300">
-            <span class="thumb-grid-title">{{ post.data.title }}</span>
-          </a>
-        {% else %}
-          {# Fallback: use first processed image from collections.images #}
-          {% set thumbnail = "" %}
-          {% for image in collections.images %}
-            {% if image.url == post.url and thumbnail == "" %}
-              {% set thumbnail = image.src %}
-            {% endif %}
-          {% endfor %}
-          {% if thumbnail %}
-            <a href="{{ post.url }}" class="thumb-grid-item">
-              <img src="{{ thumbnail }}" alt="{{ post.data.title }}" loading="lazy" decoding="async">
-              <span class="thumb-grid-title">{{ post.data.title }}</span>
-            </a>
-          {% endif %}
-        {% endif %}
-      {% endif %}
-    {% endfor %}
-  </div>
-  
-
-</section>
-{% endif %}
-
 <script>
 (function() {
   'use strict';
@@ -153,7 +120,7 @@ layout: layouts/base.njk
   // Logical plot resolution for placement (not CSS pixels).
   const GRID_COLUMNS = 24;
   const GRID_ROWS = 16;
-  // Keep a no-fly zone around headline/avatar so piles orbit the center.
+  // Keep a no-fly zone around headline/avatar so dots orbit the center.
   const HERO_BLOCK_COL_MIN = 7;
   const HERO_BLOCK_COL_MAX = 18;
   const HERO_BLOCK_ROW_MIN = 4;
@@ -310,34 +277,6 @@ layout: layouts/base.njk
       project.style.setProperty('--axis-row', String(row));
     });
   }
-
-  function updatePileTransforms(pile, pileSeed) {
-    const frames = Array.from(pile.querySelectorAll('.home-axis-pile-image'));
-    frames.forEach((frame, idx) => {
-      const seed = pileSeed + idx * 29;
-      // Per-card transform controls for each mini-pile stack.
-      const rotation = -10 + hash(seed + 1) * 20;
-      const scale = 0.78 + hash(seed + 2) * 0.26;
-      const width = 56 + hash(seed + 3) * 22;
-      const height = 54 + hash(seed + 4) * 18;
-      const offsetX = -18 + hash(seed + 5) * 36;
-      const offsetY = -14 + hash(seed + 6) * 28;
-
-      frame.style.setProperty('--rotation', `${rotation.toFixed(2)}deg`);
-      frame.style.setProperty('--scale', scale.toFixed(3));
-      frame.style.setProperty('--w', `${width.toFixed(1)}%`);
-      frame.style.setProperty('--h', `${height.toFixed(1)}%`);
-      frame.style.setProperty('--offset-x', `${offsetX.toFixed(1)}px`);
-      frame.style.setProperty('--offset-y', `${offsetY.toFixed(1)}px`);
-    });
-  }
-
-  projects.forEach((project, idx) => {
-    const pile = project.querySelector('.home-axis-pile');
-    if (pile) {
-      updatePileTransforms(pile, (idx + 1) * 97);
-    }
-  });
 
   placeProjects();
   window.addEventListener('resize', placeProjects, { passive: true });

--- a/content/index.njk
+++ b/content/index.njk
@@ -1,7 +1,7 @@
 ---
 layout: layouts/home.njk
 home:
-  introductionHeading: Operating at the intersection of product strategy, technology, and human behavior 
-  introductionText: 
+  introductionHeading: Operating at the intersection of product strategy, technology, and human behavior
+  introductionText: "Product designer and creative technologist, 15+ years. I've shipped operating system experiences at Amazon, real-time communication tools at Google, and healthcare platforms for clinical teams at Providence. My work lives at the intersection of complex systems and the humans who depend on them."
   featuredProjectThumbnailLimit: 12
 ---

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -627,68 +627,137 @@ header {
 	display: block;
 }
 
-/* --- Featured projects grid (semi-featured cards) ------------------------ */
+/* --- Featured projects grid (semi-featured rows) ------------------------- */
 
 .home-featured-grid {
-	display: grid;
-	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-	gap: 1.5rem;
 	margin: 2rem 0;
+	display: grid;
 }
 
-.home-featured-card {
+.home-featured-row {
+	width: 100vw;
+	margin-left: calc(50% - 50vw);
+	position: relative;
+	display: flex;
+	align-items: center;
+	min-height: clamp(4.5rem, 8vw, 6rem);
+	padding: clamp(1rem, 2.4vw, 1.4rem) max(var(--site-gutter), 1.25rem);
+	border-top: 1px solid var(--anp-crust);
+	background: var(--surface-color);
 	text-decoration: none;
 	color: inherit;
-	display: grid;
-	gap: 0.6rem;
-}
-
-.home-featured-thumb {
-	aspect-ratio: 4/3;
 	overflow: hidden;
-	background: var(--surface-color-alt);
-	border-radius: 6px;
+	isolation: isolate;
+	transition: color 0.22s ease, background-color 0.22s ease;
 }
 
-.home-featured-thumb img,
-.home-featured-img {
+.home-featured-row:last-child {
+	border-bottom: 1px solid var(--anp-crust);
+}
+
+.home-featured-row::after {
+	content: "";
+	position: absolute;
+	inset: 0;
+	background: linear-gradient(90deg, rgba(24, 21, 16, 0.86) 0%, rgba(24, 21, 16, 0.58) 46%, rgba(24, 21, 16, 0.18) 100%);
+	opacity: 0;
+	transition: opacity 0.22s ease;
+	z-index: 1;
+}
+
+.home-featured-row-media {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	opacity: 0;
+	transform: scale(1.02);
+	transition: opacity 0.22s ease, transform 0.22s ease;
+	z-index: 0;
+}
+
+.home-featured-row-media-frame {
+	flex: 1 1 0;
+	min-width: 0;
+	overflow: hidden;
+}
+
+.home-featured-row-media-frame picture {
+	display: block;
+	width: 100%;
+	height: 100%;
+}
+
+.home-featured-row-media-frame img,
+.home-featured-row-media-img {
 	width: 100%;
 	height: 100%;
 	object-fit: cover;
 	display: block;
 }
 
-.home-featured-placeholder {
-	width: 100%;
-	height: 100%;
+.home-featured-row-title {
+	position: relative;
+	z-index: 2;
+	display: block;
+	font-family: var(--font-family-headline-flex);
+	font-size: clamp(1.35rem, 3vw, 2.7rem);
+	font-weight: var(--font-weight-black);
+	line-height: 0.95;
+	letter-spacing: -0.03em;
+	max-width: 12ch;
+	text-wrap: balance;
+}
+
+.home-featured-row:hover,
+.home-featured-row:focus-visible {
+	color: var(--text-color-on-accent);
+	background-color: #1f1b15;
+}
+
+.home-featured-row:hover::after,
+.home-featured-row:focus-visible::after,
+.home-featured-row:hover .home-featured-row-media,
+.home-featured-row:focus-visible .home-featured-row-media {
+	opacity: 1;
+}
+
+.home-featured-row:hover .home-featured-row-media,
+.home-featured-row:focus-visible .home-featured-row-media {
+	transform: scale(1);
+}
+
+.home-featured-row:hover,
+.home-featured-row:focus-visible,
+.home-featured-row:hover:visited,
+.home-featured-row:focus-visible:visited {
+	text-decoration: none;
+	color: var(--text-color-on-accent);
+}
+
+.home-featured-row--no-media::after,
+.home-featured-row--no-media .home-featured-row-media {
+	display: none;
+}
+
+.home-featured-row--no-media:hover,
+.home-featured-row--no-media:focus-visible,
+.home-featured-row--no-media:hover:visited,
+.home-featured-row--no-media:focus-visible:visited {
 	background: var(--surface-color-alt);
-	display: flex;
-	align-items: flex-end;
-	padding: 0.75rem;
-}
-
-.home-featured-placeholder-label {
-	font-size: 0.75rem;
-	color: var(--text-color-muted);
-}
-
-.home-featured-title {
-	font-size: 0.9375rem;
-	font-weight: var(--font-weight-semibold);
-	display: block;
-}
-
-.home-featured-tagline {
-	font-size: 0.8125rem;
-	color: var(--text-color-muted);
-	display: block;
-	line-height: 1.4;
+	color: inherit;
 }
 
 @media (max-width: 640px) {
-	.home-featured-grid { grid-template-columns: 1fr; }
-}
+	.home-featured-row {
+		min-height: auto;
+		padding-block: 1.05rem;
+	}
 
+	.home-featured-row-title {
+		font-size: clamp(1.2rem, 8vw, 2rem);
+		max-width: 100%;
+	}
+}
 /* --- CTA row (replaces in-stage see-all-link) ----------------------------- */
 
 .home-cta-row {

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -705,7 +705,7 @@ header {
 	font-family: var(--font-family-headline-flex);
 	font-size: clamp(1.75rem, 4vw, 2.5rem);
 	line-height: 0.95;
-	font-weight: 760;
+	font-weight: var(--font-weight-black);
 	font-variation-settings: 'wght' 800, 'wdth' 50, 'opsz' 64, 'slnt' -5;
 	letter-spacing: -0.02em;
 	color: color-mix(in srgb, var(--text-color) 88%, var(--anp-base));
@@ -744,9 +744,7 @@ header {
 }
 
 .home-featured-row:hover .home-featured-row-title,
-.home-featured-row:focus-visible .home-featured-row-title,
-.home-featured-row:hover:visited .home-featured-row-title,
-.home-featured-row:focus-visible:visited .home-featured-row-title {
+.home-featured-row:focus-visible .home-featured-row-title {
 	color: var(--text-color-on-accent);
 }
 
@@ -763,9 +761,7 @@ header {
 }
 
 .home-featured-row--no-media:hover .home-featured-row-title,
-.home-featured-row--no-media:focus-visible .home-featured-row-title,
-.home-featured-row--no-media:hover:visited .home-featured-row-title,
-.home-featured-row--no-media:focus-visible:visited .home-featured-row-title {
+.home-featured-row--no-media:focus-visible .home-featured-row-title {
 	color: inherit;
 }
 

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -705,7 +705,6 @@ header {
 	font-family: var(--font-family-headline-flex);
 	font-size: clamp(1.75rem, 4vw, 2.5rem);
 	line-height: 0.95;
-	font-weight: var(--font-weight-black);
 	font-variation-settings: 'wght' 800, 'wdth' 50, 'opsz' 64, 'slnt' -5;
 	letter-spacing: -0.02em;
 	color: color-mix(in srgb, var(--text-color) 88%, var(--anp-base));

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -639,16 +639,17 @@ header {
 	margin-left: calc(50% - 50vw);
 	position: relative;
 	display: flex;
+	justify-content: center;
 	align-items: center;
-	min-height: clamp(4.5rem, 8vw, 6rem);
-	padding: clamp(1rem, 2.4vw, 1.4rem) max(var(--site-gutter), 1.25rem);
+	height: clamp(4.75rem, 8vw, 6rem);
+	padding: 0 max(var(--site-gutter), 1.25rem);
 	border-top: 1px solid var(--anp-crust);
-	background: var(--surface-color);
+	background: transparent;
 	text-decoration: none;
 	color: inherit;
 	overflow: hidden;
 	isolation: isolate;
-	transition: color 0.22s ease, background-color 0.22s ease;
+	transition: color 0.22s ease;
 }
 
 .home-featured-row:last-child {
@@ -699,19 +700,27 @@ header {
 	position: relative;
 	z-index: 2;
 	display: block;
+	margin: 0;
+	width: 100%;
 	font-family: var(--font-family-headline-flex);
-	font-size: clamp(1.35rem, 3vw, 2.7rem);
-	font-weight: var(--font-weight-black);
+	font-size: clamp(1.75rem, 4vw, 2.5rem);
 	line-height: 0.95;
-	letter-spacing: -0.03em;
-	max-width: 12ch;
-	text-wrap: balance;
+	font-weight: 760;
+	font-variation-settings: 'wght' 800, 'wdth' 50, 'opsz' 64, 'slnt' -5;
+	letter-spacing: -0.02em;
+	color: color-mix(in srgb, var(--text-color) 88%, var(--anp-base));
+	text-shadow: 0 8px 24px rgba(0, 0, 0, 0.07);
+	text-transform: uppercase;
+	text-align: center;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .home-featured-row:hover,
 .home-featured-row:focus-visible {
 	color: var(--text-color-on-accent);
-	background-color: #1f1b15;
+	text-decoration: none;
 }
 
 .home-featured-row:hover::after,
@@ -734,6 +743,13 @@ header {
 	color: var(--text-color-on-accent);
 }
 
+.home-featured-row:hover .home-featured-row-title,
+.home-featured-row:focus-visible .home-featured-row-title,
+.home-featured-row:hover:visited .home-featured-row-title,
+.home-featured-row:focus-visible:visited .home-featured-row-title {
+	color: var(--text-color-on-accent);
+}
+
 .home-featured-row--no-media::after,
 .home-featured-row--no-media .home-featured-row-media {
 	display: none;
@@ -743,19 +759,19 @@ header {
 .home-featured-row--no-media:focus-visible,
 .home-featured-row--no-media:hover:visited,
 .home-featured-row--no-media:focus-visible:visited {
-	background: var(--surface-color-alt);
+	color: inherit;
+}
+
+.home-featured-row--no-media:hover .home-featured-row-title,
+.home-featured-row--no-media:focus-visible .home-featured-row-title,
+.home-featured-row--no-media:hover:visited .home-featured-row-title,
+.home-featured-row--no-media:focus-visible:visited .home-featured-row-title {
 	color: inherit;
 }
 
 @media (max-width: 640px) {
-	.home-featured-row {
-		min-height: auto;
-		padding-block: 1.05rem;
-	}
-
 	.home-featured-row-title {
-		font-size: clamp(1.2rem, 8vw, 2rem);
-		max-width: 100%;
+		font-size: clamp(1.2rem, 7vw, 1.85rem);
 	}
 }
 /* --- CTA row (replaces in-stage see-all-link) ----------------------------- */

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -379,8 +379,8 @@ header {
 	display: grid;
 	grid-template-columns: repeat(24, minmax(0, 1fr));
 	grid-template-rows: repeat(16, minmax(0, 1fr));
-	min-height: calc(100svh - var(--homepage-top-offset));
-	max-height: calc(100svh - var(--homepage-top-offset));
+	min-height: clamp(300px, 30vh, 420px);
+	max-height: clamp(300px, 30vh, 420px);
 	border-radius: 1rem;
 	overflow: hidden;
 	padding: 1rem;
@@ -445,7 +445,7 @@ header {
 
 .home-axis-label {
 	position: absolute;
-	font-size: 0.7rem;
+	font-size: 0.85rem;
 	letter-spacing: 0.16em;
 	text-transform: uppercase;
 	font-weight: var(--font-weight-semibold);
@@ -596,6 +596,194 @@ header {
 	background: color-mix(in srgb, var(--surface-color) 84%, transparent);
 	backdrop-filter: blur(2px);
 	border: 1px solid color-mix(in srgb, var(--anp-overlay0) 24%, transparent);
+}
+
+/* --- Axis dot (circle → square on hover) --------------------------------- */
+
+.home-axis-dot {
+	width: 40px;
+	height: 40px;
+	border-radius: 50%;
+	overflow: hidden;
+	transition: border-radius 0.22s ease, width 0.22s ease, height 0.22s ease;
+	box-shadow: 0 2px 8px var(--shadow-color);
+	background: var(--surface-color-alt);
+}
+
+.home-axis-dot-img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.home-axis-project-link:hover .home-axis-dot {
+	border-radius: 4px;
+	width: 72px;
+	height: 54px;
+}
+
+.home-axis-project-link:hover .home-axis-project-title {
+	display: block;
+}
+
+/* --- Featured projects grid (semi-featured cards) ------------------------ */
+
+.home-featured-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+	gap: 1.5rem;
+	margin: 2rem 0;
+}
+
+.home-featured-card {
+	text-decoration: none;
+	color: inherit;
+	display: grid;
+	gap: 0.6rem;
+}
+
+.home-featured-thumb {
+	aspect-ratio: 4/3;
+	overflow: hidden;
+	background: var(--surface-color-alt);
+	border-radius: 6px;
+}
+
+.home-featured-thumb img,
+.home-featured-img {
+	width: 100%;
+	height: 100%;
+	object-fit: cover;
+	display: block;
+}
+
+.home-featured-placeholder {
+	width: 100%;
+	height: 100%;
+	background: var(--surface-color-alt);
+	display: flex;
+	align-items: flex-end;
+	padding: 0.75rem;
+}
+
+.home-featured-placeholder-label {
+	font-size: 0.75rem;
+	color: var(--text-color-muted);
+}
+
+.home-featured-title {
+	font-size: 0.9375rem;
+	font-weight: var(--font-weight-semibold);
+	display: block;
+}
+
+.home-featured-tagline {
+	font-size: 0.8125rem;
+	color: var(--text-color-muted);
+	display: block;
+	line-height: 1.4;
+}
+
+@media (max-width: 640px) {
+	.home-featured-grid { grid-template-columns: 1fr; }
+}
+
+/* --- CTA row (replaces in-stage see-all-link) ----------------------------- */
+
+.home-cta-row {
+	margin: 0.5rem 0 2rem;
+}
+
+.home-cta-row a {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	font-size: 0.9375rem;
+	font-weight: var(--font-weight-medium);
+	color: var(--text-color-link);
+	text-decoration: none;
+}
+
+.home-cta-row a:hover {
+	text-decoration: underline;
+}
+
+/* --- Podcast feature card ------------------------------------------------ */
+
+.home-podcast-feature {
+	padding: 2rem 0;
+	border-top: 1px solid var(--anp-crust);
+}
+
+.home-podcast-grid {
+	display: grid;
+	grid-template-columns: 240px 1fr;
+	gap: 2rem;
+	align-items: start;
+}
+
+.home-podcast-cover {
+	border-radius: 8px;
+	overflow: hidden;
+	background: var(--surface-color-alt);
+}
+
+.home-podcast-cover img {
+	width: 100%;
+	display: block;
+}
+
+.home-podcast-title {
+	font-size: clamp(1.1rem, 2vw, 1.4rem);
+	font-weight: var(--font-weight-bold);
+	margin: 0 0 0.5rem;
+}
+
+.home-podcast-desc {
+	font-size: 0.9375rem;
+	color: var(--text-color-muted);
+	line-height: 1.5;
+	max-width: 52ch;
+	margin: 0 0 1rem;
+}
+
+.home-podcast-all-link {
+	margin-top: 0.5rem;
+	display: inline-block;
+}
+
+@media (max-width: 640px) {
+	.home-podcast-grid { grid-template-columns: 1fr; }
+	.home-podcast-cover { max-width: 160px; }
+}
+
+/* --- Obsidian aside row -------------------------------------------------- */
+
+.home-aside-row {
+	display: flex;
+	gap: 0.5rem;
+	align-items: baseline;
+	padding: 1rem 0;
+	border-top: 1px solid var(--anp-crust);
+	font-size: 0.85rem;
+	color: var(--text-color-muted);
+}
+
+.home-aside-label {
+	font-weight: var(--font-weight-semibold);
+	text-transform: uppercase;
+	letter-spacing: 0.08em;
+	font-size: 0.75rem;
+	flex-shrink: 0;
+}
+
+.home-aside-row a {
+	color: var(--text-color-muted);
+}
+
+.home-aside-row a:hover {
+	color: var(--text-color-link);
 }
 
 .home-supporting-content {
@@ -950,8 +1138,8 @@ header {
 	}
 
 	.home-axis-stage {
-		min-height: calc(100svh - var(--homepage-top-offset-mobile));
-		max-height: calc(100svh - var(--homepage-top-offset-mobile));
+		min-height: clamp(260px, 28vh, 380px);
+		max-height: clamp(260px, 28vh, 380px);
 		grid-template-rows: repeat(12, minmax(0, 1fr));
 	}
 


### PR DESCRIPTION
## Homepage Structure v2

Executes the `2026-08-03_homepage-redesign.md` plan. All sections built per spec.

### Page flow (top → bottom)
1. **Axis hero** — Compressed to `clamp(300px, 30vh, 420px)`. Dot markers replace stacked-pile art. Each dot is a circular cropped project image; hover expands to square + reveals title chip.
2. **Intro text** — Draft B copy wired into `introductionText`. Displays immediately below the hero.
3. **Featured work grid** — `homeFeaturedProjects.njk` partial iterates `collections.semiFeaturedProjects`. Thumbnail + title + `description:` field. Placeholder card for projects without images.
4. **CTA row** — Standalone "See all work →" link. Moved out of the axis stage.
5. **Podcast card** — New 2-col layout: SCD cover left (existing `public/img/podcast/scd-podcast-cover.png`), title + description + two Simplecast embeds + "All episodes" link right.
6. **Aside row** — Obsidian Time Blocks replaced the full feature card with a slim single-line footnote.
7. **Contact links** — Unchanged.

### Files changed
| File | Change |
|------|--------|
| `content/index.njk` | `introductionText` set to Draft B |
| `_includes/layouts/home.njk` | Full restructure — dots, removed in-stage CTA, added featured/CTA/podcast/aside, dropped thumb grid |
| `_includes/homeFeaturedProjects.njk` | **New** partial for featured card grid |
| `public/css/index.css` | Axis height, dot styles, label size bump, featured grid, CTA row, podcast card, aside row |

### What this defers (per plan)
- Content rewrites on individual project `description:` fields
- PwC password-protected page, AI practice page, About page
- `/design/` intro paragraph
- Final intro text copy pick (Draft B is the build placeholder)
