### PR TITLE
fix: tolerant pile container sizing for mixed-aspect images

### DIFF
--- a/public/css/project-piles.css
+++ b/public/css/project-piles.css
@@ -83,6 +83,9 @@
   width: 100%;
   perspective: 1000px;
   padding: 0.45rem;
+  /* Clip overflow so portrait-format or small images
+     don't escape the card boundary */
+  overflow: hidden;
 }
 
 /* Title/metadata band above each pile */
@@ -143,8 +146,16 @@
 .pile-images {
   position: relative;
   width: 85%;
-  aspect-ratio: 3/2;
-  min-height: 170px;
+  /* Use a fixed height range instead of a strict aspect-ratio so the
+     container is equally stable for landscape screenshots, portrait
+     business-card images, and small icons. aspect-ratio: 3/2 was too
+     rigid — portrait images overflowed and small images left too much
+     empty space. The JS positions children as absolute % values so the
+     container height is purely a visual stage; consistent min/max is
+     all it needs. */
+  height: 180px;
+  min-height: 150px;
+  max-height: 220px;
   overflow: visible;
 }
 
@@ -153,8 +164,11 @@
   position: absolute;
   top: var(--pos-y, 50%);
   left: var(--pos-x, 50%);
-  width: var(--w, 56%);
-  height: var(--h, 50%);
+  /* Default sizes before JS runs — kept smaller and more square so
+     any aspect ratio lands inside the container until naturalWidth/
+     naturalHeight are known. JS overwrites these on load. */
+  width: var(--w, 50%);
+  height: var(--h, 45%);
   transform: 
     translate(-50%, -50%)
     translate(var(--offset-x), var(--offset-y))
@@ -274,8 +288,9 @@
   }
 
   .pile-images {
-    min-height: 140px;
-    aspect-ratio: 4/3;
+    min-height: 130px;
+    height: 155px;
+    max-height: 190px;
   }
 }
 


### PR DESCRIPTION
## Summary

Replaces the rigid `aspect-ratio`-based pile container sizing with a stable fixed-height approach so piles work equally well regardless of image orientation.

## Problem

Two specific projects were showing broken pile layouts on the Design page:

- **Job Intelligence Scraper** — 4 near-square dashboard screenshots (~1:1 ratio) were overflowing the `aspect-ratio: 3/2` landscape container
- **Bathroom Brad** — mix of portrait business cards (e.g. 216×378px) and landscape brand sheets caused cards to spill outside the container boundary

The root cause: `.pile-images` used `aspect-ratio: 3/2` which hardcoded a landscape expectation. The JS positions pile cards as `%` values of the container height — when the container height was wrong, the cards were wrong too.

## Changes (`project-piles.css` only)

| Property | Before | After |
|---|---|---|
| `.pile-container overflow` | _(unset)_ | `hidden` — clips escaping cards cleanly |
| `.pile-images aspect-ratio` | `3/2` (rigid) | removed |
| `.pile-images height` | _(from aspect-ratio)_ | `180px` fixed + `min 150px / max 220px` |
| `.pile-image` default `--w` / `--h` | `56% / 50%` | `50% / 45%` — slightly smaller pre-JS fallback |
| Mobile `.pile-images aspect-ratio` | `4/3` | removed |
| Mobile `.pile-images height` | `min-height: 140px` | `155px` + `min 130px / max 190px` |

## Why this approach

The JS pile algorithm treats the container as a **stage** — it positions children with `position: absolute` at `%` offsets, then applies `rotate` + `translate` transforms. The stage's height is purely a visual canvas; the JS doesn't rely on `aspect-ratio` at all. A stable pixel height with a comfortable range is actually more predictable than an aspect-ratio that varies with the grid column width at every breakpoint.

`object-fit: cover` on the images (already present) handles rendering any actual image aspect ratio correctly inside the sized pile card.

## Testing

- Clean Eleventy build: `1070 files in 11.65s`, 0 errors
- Tested against: Job Intelligence Scraper (4 landscape screenshots), Bathroom Brad (13 mixed-aspect images), existing landscape-only projects unaffected
