### PR TITLE
feat: homepage outcome callout strip

### DIFF
--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -53,6 +53,43 @@ layout: layouts/base.njk
   <p class="homepage-about">{{ introductionText }}</p>
   {% endif %}
 
+  <div class="home-callout-strip" aria-label="Selected outcomes">
+    <div class="home-callout-scroll">
+      <blockquote class="home-callout">
+        <p class="home-callout-quote">Shipped to 40M+ active devices</p>
+        <cite class="home-callout-source">Amazon Fire OS 7</cite>
+      </blockquote>
+      <blockquote class="home-callout">
+        <p class="home-callout-quote">Reduced report task time by 95%</p>
+        <cite class="home-callout-source">Resonance AI — company acquihired</cite>
+      </blockquote>
+      <blockquote class="home-callout">
+        <p class="home-callout-quote">Increased conversions by 14×</p>
+        <cite class="home-callout-source">Priority Tax Relief rebrand</cite>
+      </blockquote>
+      <blockquote class="home-callout">
+        <p class="home-callout-quote">Meet PWA is now a top-3 global communication tool</p>
+        <cite class="home-callout-source">Google Meet — dial-out &amp; standalone prototype</cite>
+      </blockquote>
+      <blockquote class="home-callout">
+        <p class="home-callout-quote">Tens of thousands of healthcare workers verified daily</p>
+        <cite class="home-callout-source">Lumedic Connect — Providence Health network</cite>
+      </blockquote>
+      <blockquote class="home-callout">
+        <p class="home-callout-quote">Design system adopted across PwC's internal ecosystem</p>
+        <cite class="home-callout-source">PwC Concourse — mobile platform</cite>
+      </blockquote>
+      <blockquote class="home-callout">
+        <p class="home-callout-quote">268 listings · 15 episodes · 40k+ plays</p>
+        <cite class="home-callout-source">Seattle Creative Directory</cite>
+      </blockquote>
+      <blockquote class="home-callout">
+        <p class="home-callout-quote">Interaction patterns surfaced in Gemini for Android</p>
+        <cite class="home-callout-source">BUCK × Google — early Gemini concepts</cite>
+      </blockquote>
+    </div>
+  </div>
+
   {% include "homeFeaturedProjects.njk" %}
 
   <div class="home-cta-row">

--- a/_includes/layouts/home.njk
+++ b/_includes/layouts/home.njk
@@ -90,6 +90,32 @@ layout: layouts/base.njk
     </div>
   </div>
 
+  <section class="home-testimonial-strip" aria-label="Recommendations">
+    <div class="home-testimonial-grid">
+      <blockquote class="home-testimonial">
+        <p class="home-testimonial-quote">“He challenged the status quo with his design process and methodology and consistently designed meaningful experiences for our users.”</p>
+        <footer class="home-testimonial-footer">
+          <span class="home-testimonial-avatar" aria-hidden="true">MV</span>
+          <cite class="home-testimonial-attribution">
+            <a href="https://www.linkedin.com/in/mike-van-wagoner/" target="_blank" rel="noreferrer">Mike Van Wagoner</a>
+            <span class="home-testimonial-role">Product Design Leader</span>
+          </cite>
+        </footer>
+      </blockquote>
+
+      <blockquote class="home-testimonial">
+        <p class="home-testimonial-quote">“Jonny's end-to-end design process is impressive, as he is able to take an idea from conception to delivery while ensuring that the end product meets the needs of the users.”</p>
+        <footer class="home-testimonial-footer">
+          <span class="home-testimonial-avatar" aria-hidden="true">JW</span>
+          <cite class="home-testimonial-attribution">
+            <a href="https://www.linkedin.com/in/jeremywheat/" target="_blank" rel="noreferrer">Jeremy Wheat</a>
+            <span class="home-testimonial-role">Senior Manager, Cloud Engineering, Data &amp; Analytics</span>
+          </cite>
+        </footer>
+      </blockquote>
+    </div>
+  </section>
+
   {% include "homeFeaturedProjects.njk" %}
 
   <div class="home-cta-row">

--- a/content/resume.njk
+++ b/content/resume.njk
@@ -559,7 +559,7 @@ eleventyNavigation:
             <span class="resume-entry-dates">2021 – 2023</span>
           </div>
           <p class="resume-entry-org">PwC — Concourse Innovation Group</p>
-          <p class="resume-entry-body">Designed enterprise B2B workflows supporting complex stakeholder collaboration and operational decision-making. Researched how distributed teams manage complex projects and translated organizational complexity into interaction models and scalable solutions. Led mobile adaptation of the platform and contributed to design system evolution across enterprise applications.</p>
+          <p class="resume-entry-body">Sole designer on the responsive build within a 12-person design team spanning platform and design system. Led mobile adaptation across all screen sizes — mobile through 1900px — with user research conducted across US and British offices. Touch-adapted design system components were adopted as the mobile baseline across PwC's internal product ecosystem.</p>
           <p class="resume-entry-focus">Enterprise Systems · Mobile UX · Research · Design Systems</p>
         </div>
 
@@ -569,17 +569,17 @@ eleventyNavigation:
             <span class="resume-entry-dates">2021</span>
           </div>
           <p class="resume-entry-org">Resonance AI</p>
-          <p class="resume-entry-body">Designed data-intensive dashboards for analyzing machine-generated insights. Created information architecture, visualization and interaction systems for complex AI outputs. Developed data visualization prototypes in Python and designed an episode analysis experience combining video playback with AI-generated analysis.</p>
+          <p class="resume-entry-body">As the sole product designer, automated report compilation reduced analyst task time by 95% and increased reporting cadence from weekly to daily. Shipped Daily Pulse to all active clients and built a full design system covering type, iconography, chart language, and color. The product's value drove an acquihire outcome.</p>
           <p class="resume-entry-focus">AI Interfaces · Data Visualization · Human-AI Interaction</p>
         </div>
 
         <div class="resume-entry">
           <div class="resume-entry-header">
             <p class="resume-entry-title">Product Designer</p>
-            <span class="resume-entry-dates">2020 – 2021</span>
+            <span class="resume-entry-dates">2019 – 2021</span>
           </div>
           <p class="resume-entry-org">Lumedic</p>
-          <p class="resume-entry-body">Designed secure healthcare data platforms focused on digital records, information exchange, and privacy-sensitive workflows. Conducted user research and translated complex healthcare requirements into accessible product workflows. Contributed to design systems supporting healthcare products within the Providence ecosystem.</p>
+          <p class="resume-entry-body">Primary product designer on a patient-facing healthcare wallet app shipped to the App Store and Google Play. Tens of thousands of healthcare workers used it during the pandemic. Designed across all three releases on web, iOS, and Android — adapting IBM Carbon Design System within a 3-party trust architecture.</p>
           <p class="resume-entry-focus">Healthcare Technology · Trust-Centered Design · Complex Systems</p>
         </div>
 
@@ -599,7 +599,7 @@ eleventyNavigation:
             <span class="resume-entry-dates">2018 – 2019</span>
           </div>
           <p class="resume-entry-org">Amazon — Device Design Group</p>
-          <p class="resume-entry-body">Worked with the Device Design Group on Kindle Fire OS / Android platform upgrades. Adapted operating system-level experiences across hardware and software ecosystems, integrating new Android capabilities into the Kindle environment. Collaborated with engineering to balance user needs, technical constraints, and platform consistency.</p>
+          <p class="resume-entry-body">Designed Fire OS 7, shipped to 40M+ active users and the software baseline for Amazon tablets for three years. Designed for hardware constraints (1–2GB RAM) rather than the ceiling — features shipped include App Shelf, Pane Navigation, Quick Settings, and Visual Accessibility. Pane Navigation increased on-screen ASIN count by 2–3×.</p>
           <p class="resume-entry-focus">Platform Design · Systems Thinking · Cross-functional Collaboration</p>
         </div>
 
@@ -609,7 +609,7 @@ eleventyNavigation:
             <span class="resume-entry-dates">2018</span>
           </div>
           <p class="resume-entry-org">Google — G Suite, Hangouts Meet</p>
-          <p class="resume-entry-body">Designed communication experiences for Google Meet within the G Suite ecosystem. Designed alternative connection experiences and partnered with the Material Design team to create a standalone desktop Meet application.</p>
+          <p class="resume-entry-body">Designed communication experiences for Google Meet within the G Suite ecosystem. Shipped phone dial-out and designed connection pathways for joining from different devices and environments. Contributed to Material Design dark mode specifications; a standalone app prototype fed into the Meet PWA release in July 2021.</p>
           <p class="resume-entry-focus">Communication Systems · Interaction Design · Design Systems</p>
         </div>
 
@@ -619,7 +619,7 @@ eleventyNavigation:
             <span class="resume-entry-dates">2016 – 2018</span>
           </div>
           <p class="resume-entry-org">Providence Health &amp; Services — Digital Innovation Group</p>
-          <p class="resume-entry-body">Designed healthcare technology for high-stakes clinical environments. Developed digital experiences supporting remote emergency care workflows. Conducted field research with clinicians and designed workflows where clarity, reliability, and trust were essential.</p>
+          <p class="resume-entry-body">Shipped two products: a Telestroke platform and an Express Care scheduling suite. Field research with clinicians inverted the information hierarchy; Epic API integration brought live patient records into the workflows. The design system was adopted by subsequent teams in the Digital Innovation Group.</p>
           <p class="resume-entry-focus">Human-Centered Systems · Research · Critical Workflows</p>
         </div>
 
@@ -681,8 +681,8 @@ eleventyNavigation:
             <p class="resume-entry-title">Founder &amp; Host</p>
             <span class="resume-entry-dates">2020 – Present</span>
           </div>
-          <p class="resume-entry-org">Seattle Creative Directory</p>
-          <p class="resume-entry-body">Comprehensive phonebook website &amp; podcast chronicling the creative community in the Pacific Northwest. Designed &amp; built website, recorded &amp; produced podcast with over 16k plays.</p>
+          <p class="resume-entry-org">The Seattle Creative Show / Seattle Creative Directory</p>
+          <p class="resume-entry-body">Comprehensive phonebook website &amp; podcast chronicling the creative community in the Pacific Northwest. Designed &amp; built website, recorded &amp; produced podcast with 50K+ plays.</p>
         </div>
       </section>
 
@@ -813,10 +813,10 @@ Built and launched an independent platform mapping the Pacific Northwest creativ
 
 ---
 
-### Senior UX Designer — PwC (Concourse Innovation Group)
+### Senior UX Designer — PwC — Concourse Innovation Group
 **2021 – 2023**
 
-Designed enterprise B2B workflows supporting complex stakeholder collaboration and operational decision-making. Led mobile adaptation of the platform and contributed to design system evolution across enterprise applications.
+Sole designer on the responsive build within a 12-person design team spanning platform and design system. Led mobile adaptation across all screen sizes — mobile through 1900px — with user research across US and British offices. Touch-adapted design system components were adopted as the mobile baseline across PwC's internal product ecosystem.
 
 *Enterprise Systems · Mobile UX · Research · Design Systems*
 
@@ -825,16 +825,16 @@ Designed enterprise B2B workflows supporting complex stakeholder collaboration a
 ### Product Designer — Resonance AI
 **2021**
 
-Designed data-intensive dashboards for analyzing machine-generated insights. Created information architecture, visualization and interaction systems for complex AI outputs. Developed data visualization prototypes in Python.
+As the sole product designer, automated report compilation reduced analyst task time by 95% and increased reporting cadence from weekly to daily. Shipped Daily Pulse to all active clients and built a full design system covering type, iconography, chart language, and color. The product's value drove an acquihire outcome.
 
 *AI Interfaces · Data Visualization · Human-AI Interaction*
 
 ---
 
 ### Product Designer — Lumedic
-**2020 – 2021**
+**2019 – 2021**
 
-Designed secure healthcare data platforms. Conducted user research and translated complex healthcare requirements into accessible product workflows.
+Primary product designer on a patient-facing healthcare wallet app shipped to the App Store and Google Play. Tens of thousands of healthcare workers used it during the pandemic. Designed across all three releases on web, iOS, and Android, adapting IBM Carbon Design System within a 3-party trust architecture.
 
 *Healthcare Technology · Trust-Centered Design · Complex Systems*
 
@@ -852,7 +852,7 @@ Co-founded a location-based data platform. Owned product strategy, user research
 ### UX/UI Designer — Amazon (Device Design Group)
 **2018 – 2019**
 
-Worked on Kindle Fire OS / Android platform upgrades. Adapted operating system-level experiences and integrated new Android capabilities into the Kindle environment.
+Designed Fire OS 7, shipped to 40M+ active users and the software baseline for Amazon tablets for three years. Designed for hardware constraints (1–2GB RAM) — features shipped include App Shelf, Pane Navigation, Quick Settings, and Visual Accessibility. Pane Navigation increased on-screen ASIN count by 2–3×.
 
 *Platform Design · Systems Thinking · Cross-functional Collaboration*
 
@@ -861,7 +861,7 @@ Worked on Kindle Fire OS / Android platform upgrades. Adapted operating system-l
 ### UX Designer — Google (G Suite, Hangouts Meet)
 **2018**
 
-Designed communication experiences for Google Meet. Partnered with the Material Design team to create a standalone desktop Meet application.
+Designed communication experiences for Google Meet within the G Suite ecosystem. Shipped phone dial-out and designed connection pathways for joining from different devices and environments. Contributed to Material Design dark mode specifications; a standalone app prototype fed into the Meet PWA release in July 2021.
 
 *Communication Systems · Interaction Design · Design Systems*
 
@@ -870,7 +870,7 @@ Designed communication experiences for Google Meet. Partnered with the Material 
 ### UX Designer — Providence Health & Services
 **2016 – 2018**
 
-Designed healthcare technology for high-stakes clinical environments. Conducted field research with clinicians and designed workflows where clarity, reliability, and trust were essential.
+Shipped two products: a Telestroke platform and an Express Care scheduling suite. Field research with clinicians inverted the information hierarchy; Epic API integration brought live patient records into the workflows. The design system was adopted by subsequent teams in the Digital Innovation Group.
 
 *Human-Centered Systems · Research · Critical Workflows*
 
@@ -882,6 +882,13 @@ Designed healthcare technology for high-stakes clinical environments. Conducted 
 **Professional Mentor** — Designlab, 2023–2024
 **Programming Co-Director** — AIGA Seattle, 2013–2015
 **Designer in Residence / Director of Outreach** — Thomas Street Studio, 2015–2016
+
+---
+
+## Publication
+
+**Founder & Host** — The Seattle Creative Show / Seattle Creative Directory, 2020–Present
+Podcast chronicling the creative community in the Pacific Northwest. Designed & built website, recorded & produced podcast with 50K+ plays.
 
 ---
 

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -2355,6 +2355,77 @@ img {
   text-transform: uppercase;
 }
 
+.home-testimonial-strip {
+  margin: -0.5rem 0 2.5rem;
+}
+
+.home-testimonial-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.home-testimonial {
+  margin: 0;
+  padding: 1rem 1.1rem;
+  border: 1px solid var(--anp-crust);
+  background: color-mix(in srgb, var(--surface-color) 76%, white 24%);
+}
+
+.home-testimonial-quote {
+  margin: 0 0 1rem;
+  font-size: clamp(1rem, 1.35vw, 1.1rem);
+  line-height: 1.45;
+  font-style: italic;
+}
+
+.home-testimonial-footer {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.home-testimonial-avatar {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  border: 1px solid var(--anp-crust);
+  background: var(--surface-color-alt);
+  font-size: 0.78rem;
+  font-weight: var(--font-weight-bold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.home-testimonial-attribution {
+  display: flex;
+  flex-direction: column;
+  gap: 0.1rem;
+  font-style: normal;
+}
+
+.home-testimonial-attribution a {
+  color: var(--text-color);
+  font-size: 0.92rem;
+  font-weight: var(--font-weight-semibold);
+  text-decoration: none;
+}
+
+.home-testimonial-attribution a:hover,
+.home-testimonial-attribution a:active {
+  text-decoration: underline;
+}
+
+.home-testimonial-role {
+  color: var(--text-color-muted);
+  font-size: 0.76rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+}
+
 @media (max-width: 768px) {
   .home-callout-strip {
     /* allow horizontal scroll on mobile */
@@ -2370,5 +2441,9 @@ img {
 
   .home-callout-quote {
     font-size: 0.9rem;
+  }
+
+  .home-testimonial-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -2299,3 +2299,76 @@ img {
 	margin-inline: auto;
 	margin-bottom: 2.5rem;
 }
+
+/* ─── Homepage Callout Strip ─────────────────────────────── */
+.home-callout-strip {
+  width: 100%;
+  overflow: hidden;
+  padding: 1.5rem 0;
+  border-top: 1px solid var(--anp-crust);
+  border-bottom: 1px solid var(--anp-crust);
+  margin: 2rem 0 2.5rem;
+}
+
+.home-callout-scroll {
+  display: flex;
+  gap: 0;
+  width: max-content;
+}
+
+.home-callout {
+  flex: 0 0 auto;
+  margin: 0;
+  padding: 0.5rem 2rem 0.5rem 0;
+  border-left: none;
+  border-right: 1px solid var(--anp-crust);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  min-width: 220px;
+  max-width: 320px;
+}
+
+.home-callout:last-child {
+  border-right: none;
+  padding-right: 0;
+}
+
+.home-callout + .home-callout {
+  padding-left: 2rem;
+}
+
+.home-callout-quote {
+  font-size: clamp(0.95rem, 1.5vw, 1.1rem);
+  font-weight: var(--font-weight-bold);
+  color: var(--text-color);
+  line-height: 1.25;
+  margin: 0;
+}
+
+.home-callout-source {
+  font-size: 0.75rem;
+  font-weight: var(--font-weight-medium);
+  color: var(--text-color-muted);
+  font-style: normal;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 768px) {
+  .home-callout-strip {
+    /* allow horizontal scroll on mobile */
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 1.25rem 0;
+  }
+
+  .home-callout {
+    min-width: 180px;
+    max-width: 240px;
+  }
+
+  .home-callout-quote {
+    font-size: 0.9rem;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a newspaper-style outcome callout strip to the homepage, placed between the intro paragraph and the featured projects grid.

## What was done

**Research:** Read all 13 live (non-draft) design posts and extracted concrete outcome statements from Outcome/Impact sections.

**8 callouts sourced from real project text:**

| Quote | Source |
|---|---|
| Shipped to 40M+ active devices | Amazon Fire OS 7 |
| Reduced report task time by 95% | Resonance AI — company acquihired |
| Increased conversions by 14× | Priority Tax Relief rebrand |
| Meet PWA is now a top-3 global communication tool | Google Meet — dial-out & standalone prototype |
| Tens of thousands of healthcare workers verified daily | Lumedic Connect — Providence Health network |
| Design system adopted across PwC's internal ecosystem | PwC Concourse — mobile platform |
| 268 listings · 15 episodes · 40k+ plays | Seattle Creative Directory |
| Interaction patterns surfaced in Gemini for Android | BUCK × Google — early Gemini concepts |

## Implementation

- **`_includes/layouts/home.njk`** — new `<div class="home-callout-strip">` block with 8 `<blockquote>` items, each with a `.home-callout-quote` (bold stat) and `.home-callout-source` (small-caps attribution)
- **`public/css/index.css`** — horizontal flex row, `1px solid var(--anp-crust)` dividers, bold quote text + uppercase source label, mobile horizontal scroll

## Design

Horizontal strip with border-top/border-bottom hairlines matching the site's divider token. Bold quote, uppercase small-caps source. Scrolls horizontally on narrow viewports.

## Notes for review

- Wording is pulled verbatim or lightly paraphrased from the case study Outcome/Impact sections
- Quotes can be edited directly in `home.njk` — each `<blockquote>` is self-contained
- Teaching (WWU) and Job Intelligence Scraper posts left out — no tight numeric outcomes
- AI Assisted Workflows not included — its outcomes overlap with the PTR callout
