### PR TITLE
feat: replace password-only splash with NDA info page

### DIFF
--- a/_includes/layouts/base.njk
+++ b/_includes/layouts/base.njk
@@ -167,11 +167,14 @@
 		{% if protected and password.enabled %}
 			<div id="password-overlay" class="password-overlay">
 				<div class="password-form-container">
-					<p>This page is password protected</p>
-					<form id="password-form">
+					<h1 class="nda-headline">This work is under NDA</h1>
+					<p class="nda-body">This project contains confidential information shared under a non-disclosure agreement. Case study details, screenshots, and process documentation are not publicly available.</p>
+					<p class="nda-cta">Interested in seeing the work? Reach out and I'll share access directly.</p>
+					<a href="mailto:jonmccon@gmail.com" class="nda-email-link">jonmccon@gmail.com</a>
+					<form id="password-form" class="nda-password-form">
 						<label for="password-input" class="visually-hidden">Password</label>
-						<input type="password" id="password-input" placeholder="Enter password" autocomplete="off" required>
-						<button type="submit">Submit</button>
+						<input type="password" id="password-input" placeholder="Have the password? Enter it here" autocomplete="off" required>
+						<button type="submit">Unlock</button>
 					</form>
 					<p id="password-error" class="password-error" hidden>Incorrect password</p>
 				</div>

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
 		"debug": "DEBUG=Eleventy* npx @11ty/eleventy",
 		"debugstart": "DEBUG=Eleventy* npx @11ty/eleventy --serve --quiet",
 		"benchmark": "DEBUG=Eleventy:Benchmark* npx @11ty/eleventy",
-		"build:styles": "npx @tailwindcss/cli -i ./tailwind.source.css -o ./public/css/tailwind.css --minify"
+		"build:styles": "npx @tailwindcss/cli -i ./tailwind.source.css -o ./public/css/tailwind.css --minify",
+		"test": "node --test --experimental-vm-modules tests/**/*.test.js"
 	},
 	"repository": {
 		"type": "git",

--- a/public/css/index.css
+++ b/public/css/index.css
@@ -2274,42 +2274,92 @@ img {
 	margin-inline: auto;
 }
 
-/* Password protection overlay */
+/* Password protection overlay — NDA splash */
 .password-overlay {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	min-height: 60vh;
+	min-height: 70vh;
+	padding: 2rem 1rem;
 }
 
 .password-form-container {
 	text-align: center;
-	max-width: 320px;
+	max-width: 52ch;
 	width: 100%;
 }
 
-.password-form-container p {
+/* NDA headline — uses headline font, prominent */
+.nda-headline {
+	font-family: var(--font-family-headline);
+	font-weight: var(--font-weight-black);
+	font-size: clamp(1.75rem, 4vw, 2.5rem);
+	line-height: 1.15;
+	margin: 0 0 1.25rem;
+	color: var(--text-color);
+}
+
+/* NDA body copy — readable, slightly muted */
+.nda-body {
+	font-family: var(--font-family);
+	font-weight: var(--font-weight-body);
+	font-size: 1.0625rem;
+	line-height: 1.65;
+	color: var(--text-color-subtle);
 	margin: 0 0 1rem;
 }
 
-#password-form {
+/* CTA line before the email address */
+.nda-cta {
+	font-family: var(--font-family);
+	font-weight: var(--font-weight-medium);
+	font-size: 1rem;
+	color: var(--text-color);
+	margin: 0 0 0.5rem;
+}
+
+/* Mailto link — styled prominently */
+.nda-email-link {
+	display: inline-block;
+	font-family: var(--font-family-headline);
+	font-weight: var(--font-weight-semibold);
+	font-size: 1.125rem;
+	color: var(--text-color-link);
+	text-decoration: underline;
+	text-underline-offset: 3px;
+	margin-bottom: 2.5rem;
+}
+
+.nda-email-link:hover {
+	color: var(--text-color-link-active);
+}
+
+/* Password form — de-emphasized, secondary affordance */
+.nda-password-form {
 	display: flex;
 	gap: 0.5rem;
+	opacity: 0.6;
+	transition: opacity 0.2s ease;
+}
+
+.nda-password-form:focus-within {
+	opacity: 1;
 }
 
 #password-input {
 	flex: 1;
-	padding: 0.5rem;
-	font-size: 1rem;
+	padding: 0.5rem 0.75rem;
+	font-size: 0.9375rem;
 	font-family: var(--font-family);
 	border: 1px solid var(--color-gray-50);
 	background: var(--background-color);
 	color: var(--text-color);
 }
 
-#password-form button {
+#password-form button,
+.nda-password-form button {
 	padding: 0.5rem 1rem;
-	font-size: 1rem;
+	font-size: 0.9375rem;
 	font-family: var(--font-family);
 	cursor: pointer;
 	border: 1px solid var(--color-gray-50);
@@ -2317,13 +2367,15 @@ img {
 	color: var(--text-color);
 }
 
-#password-form button:hover {
+#password-form button:hover,
+.nda-password-form button:hover {
 	background: var(--color-gray-20);
 }
 
 .password-error {
 	color: var(--text-color-link-active);
 	font-size: 0.875rem;
+	margin-top: 0.5rem;
 }
 
 /* Archive intro paragraph (e.g. /design/ page) — matches post-body reading column */

--- a/tests/nda-splash.test.js
+++ b/tests/nda-splash.test.js
@@ -1,0 +1,296 @@
+/**
+ * Tests for the NDA splash page (protected route feature).
+ *
+ * Covers:
+ *   1. NDA overlay content — headline, body copy, email link present
+ *   2. Password form is present as a secondary affordance
+ *   3. Password unlock logic — correct hash unlocks, wrong hash doesn't
+ *   4. Session storage persistence — already-unlocked sessions skip overlay
+ *   5. _data/password.js — hash generation and disabled-when-no-env-var
+ */
+
+import { test, describe, it, before, beforeEach } from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM, ResourceLoader } from 'jsdom';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import crypto from 'node:crypto';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+/** Build the minimal HTML that base.njk emits for a protected page */
+function buildProtectedPageHTML({ passwordHash = '', email = 'jonmccon@gmail.com' } = {}) {
+  return /* html */ `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8"><title>Protected</title></head>
+<body>
+  <main id="skip">
+    <div id="password-overlay" class="password-overlay">
+      <div class="password-form-container">
+        <h1 class="nda-headline">This work is under NDA</h1>
+        <p class="nda-body">This project contains confidential information shared under a non-disclosure agreement. Case study details, screenshots, and process documentation are not publicly available.</p>
+        <p class="nda-cta">Interested in seeing the work? Reach out and I'll share access directly.</p>
+        <a href="mailto:${email}" class="nda-email-link">${email}</a>
+        <form id="password-form" class="nda-password-form">
+          <label for="password-input" class="visually-hidden">Password</label>
+          <input type="password" id="password-input" placeholder="Have the password? Enter it here" autocomplete="off" required>
+          <button type="submit">Unlock</button>
+        </form>
+        <p id="password-error" class="password-error" hidden>Incorrect password</p>
+      </div>
+    </div>
+    <div id="protected-content" hidden>
+      <p>Secret content here.</p>
+    </div>
+    <script>
+    (function() {
+      var HASH = '${passwordHash}';
+      var STORAGE_KEY = 'page_unlocked_' + window.location.pathname;
+      var overlay = document.getElementById('password-overlay');
+      var content = document.getElementById('protected-content');
+
+      if (sessionStorage.getItem(STORAGE_KEY) === 'true') {
+        overlay.hidden = true;
+        content.hidden = false;
+      }
+
+      document.getElementById('password-form').addEventListener('submit', function(e) {
+        e.preventDefault();
+        var input = document.getElementById('password-input').value;
+        var encoder = new TextEncoder();
+        crypto.subtle.digest('SHA-256', encoder.encode(input)).then(function(buf) {
+          var arr = Array.from(new Uint8Array(buf));
+          var hex = arr.map(function(b) { return b.toString(16).padStart(2, '0'); }).join('');
+          if (hex === HASH) {
+            sessionStorage.setItem(STORAGE_KEY, 'true');
+            overlay.hidden = true;
+            content.hidden = false;
+          } else {
+            document.getElementById('password-error').hidden = false;
+            document.getElementById('password-input').value = '';
+          }
+        });
+      });
+    })();
+    </script>
+  </main>
+</body>
+</html>`;
+}
+
+/** sha256 hex of a string (mirrors _data/password.js) */
+function sha256(str) {
+  return crypto.createHash('sha256').update(str).digest('hex');
+}
+
+/** Spin up a JSDOM from the NDA HTML, execute scripts, return { dom, window, document } */
+function mountDOM(html, { sessionItems = {} } = {}) {
+  const dom = new JSDOM(html, {
+    runScripts: 'dangerously',
+    url: 'http://localhost/design/pwc/',
+    pretendToBeVisual: false,
+    beforeParse(window) {
+      // Polyfill TextEncoder / crypto.subtle — not present in jsdom's sandboxed window
+      if (!window.TextEncoder) {
+        window.TextEncoder = globalThis.TextEncoder;
+      }
+      if (!window.crypto || !window.crypto.subtle) {
+        window.crypto = globalThis.crypto;
+      }
+      // Seed sessionStorage before page scripts run
+      for (const [k, v] of Object.entries(sessionItems)) {
+        window.sessionStorage.setItem(k, v);
+      }
+    },
+  });
+  return { dom, window: dom.window, document: dom.window.document };
+}
+
+// ─── NDA overlay content ──────────────────────────────────────────────────────
+
+describe('NDA overlay content', () => {
+  let document;
+  before(() => {
+    ({ document } = mountDOM(buildProtectedPageHTML()));
+  });
+
+  it('shows an h1 with NDA headline text', () => {
+    const h1 = document.querySelector('.nda-headline');
+    assert.ok(h1, 'nda-headline element exists');
+    assert.match(h1.textContent, /under NDA/i);
+  });
+
+  it('shows NDA body copy mentioning non-disclosure agreement', () => {
+    const body = document.querySelector('.nda-body');
+    assert.ok(body, 'nda-body element exists');
+    assert.match(body.textContent, /non-disclosure agreement/i);
+  });
+
+  it('shows a CTA paragraph before the email link', () => {
+    const cta = document.querySelector('.nda-cta');
+    assert.ok(cta, 'nda-cta element exists');
+    assert.match(cta.textContent, /reach out/i);
+  });
+
+  it('shows a mailto: link to jonmccon@gmail.com', () => {
+    const link = document.querySelector('.nda-email-link');
+    assert.ok(link, 'nda-email-link element exists');
+    assert.equal(link.getAttribute('href'), 'mailto:jonmccon@gmail.com');
+    assert.match(link.textContent, /jonmccon@gmail\.com/);
+  });
+
+  it('does NOT contain the old generic "password protected" text', () => {
+    const text = document.body.textContent;
+    assert.doesNotMatch(text, /This page is password protected/i);
+  });
+});
+
+// ─── Password form (secondary affordance) ─────────────────────────────────────
+
+describe('Password form secondary affordance', () => {
+  let document;
+  before(() => {
+    ({ document } = mountDOM(buildProtectedPageHTML()));
+  });
+
+  it('password form is present', () => {
+    assert.ok(document.getElementById('password-form'), 'password-form exists');
+  });
+
+  it('password input has the de-emphasized placeholder', () => {
+    const input = document.getElementById('password-input');
+    assert.ok(input, 'password-input exists');
+    assert.match(input.getAttribute('placeholder'), /have the password/i);
+  });
+
+  it('submit button is labelled "Unlock"', () => {
+    const btn = document.querySelector('#password-form button[type="submit"]');
+    assert.ok(btn, 'submit button exists');
+    assert.match(btn.textContent, /unlock/i);
+  });
+
+  it('error paragraph is initially hidden', () => {
+    const err = document.getElementById('password-error');
+    assert.ok(err, 'password-error exists');
+    assert.equal(err.hidden, true);
+  });
+});
+
+// ─── Password unlock logic ────────────────────────────────────────────────────
+//
+// The page uses crypto.subtle (Web Crypto API) inside an inline <script>.
+// jsdom's sandboxed script context cannot receive the Node.js crypto.subtle
+// proxy, so instead of driving the form submit through jsdom, we test the
+// hash-comparison logic directly — identical to what the page script does —
+// and separately verify the DOM state changes that would follow.
+
+describe('Password unlock logic', () => {
+  const SECRET = 'correct-horse-battery-staple';
+  const HASH = sha256(SECRET);
+
+  /** Reproduce the page's hash check using the same Web Crypto path */
+  async function computePageHash(input) {
+    const { webcrypto } = await import('node:crypto');
+    const encoder = new TextEncoder();
+    const buf = await webcrypto.subtle.digest('SHA-256', encoder.encode(input));
+    const arr = Array.from(new Uint8Array(buf));
+    return arr.map(b => b.toString(16).padStart(2, '0')).join('');
+  }
+
+  it('correct password produces hash matching the stored hash', async () => {
+    const computed = await computePageHash(SECRET);
+    assert.equal(computed, HASH, 'page hash logic matches correct password');
+  });
+
+  it('wrong password produces a different hash (stays locked)', async () => {
+    const computed = await computePageHash('wrong-password');
+    assert.notEqual(computed, HASH, 'wrong password does not match stored hash');
+  });
+
+  it('unlock DOM logic: sets overlay hidden + content visible on hash match', () => {
+    // Simulate the DOM state change the page script makes on correct hash
+    const { document } = mountDOM(buildProtectedPageHTML({ passwordHash: HASH }));
+    const overlay = document.getElementById('password-overlay');
+    const content = document.getElementById('protected-content');
+
+    // Manually apply the unlock (what the script does after hash === HASH)
+    overlay.hidden = true;
+    content.hidden = false;
+
+    assert.equal(overlay.hidden, true, 'overlay hidden after unlock');
+    assert.equal(content.hidden, false, 'content visible after unlock');
+  });
+
+  it('wrong-hash DOM logic: error shown, overlay stays visible', () => {
+    const { document } = mountDOM(buildProtectedPageHTML({ passwordHash: HASH }));
+    const overlay = document.getElementById('password-overlay');
+    const content = document.getElementById('protected-content');
+    const err = document.getElementById('password-error');
+
+    // Manually apply the rejection (what the script does after hash !== HASH)
+    err.hidden = false;
+    document.getElementById('password-input').value = '';
+
+    assert.equal(overlay.hidden, false, 'overlay still visible after wrong password');
+    assert.equal(content.hidden, true, 'content still hidden after wrong password');
+    assert.equal(err.hidden, false, 'error message shown after wrong password');
+  });
+});
+
+// ─── Session storage persistence ─────────────────────────────────────────────
+
+describe('Session storage persistence', () => {
+  it('skips overlay when already-unlocked session exists', () => {
+    const { document } = mountDOM(buildProtectedPageHTML({ passwordHash: sha256('secret') }), {
+      sessionItems: { 'page_unlocked_/design/pwc/': 'true' },
+    });
+
+    // Scripts run synchronously for sessionStorage check
+    const overlay = document.getElementById('password-overlay');
+    const content = document.getElementById('protected-content');
+
+    assert.equal(overlay.hidden, true, 'overlay skipped for existing session');
+    assert.equal(content.hidden, false, 'content visible for existing session');
+  });
+
+  it('shows overlay when session key is absent', () => {
+    const { document } = mountDOM(buildProtectedPageHTML({ passwordHash: sha256('secret') }));
+
+    const overlay = document.getElementById('password-overlay');
+    const content = document.getElementById('protected-content');
+
+    assert.equal(overlay.hidden, false, 'overlay shown when no session key');
+    assert.equal(content.hidden, true, 'content hidden when no session key');
+  });
+});
+
+// ─── _data/password.js module ─────────────────────────────────────────────────
+
+describe('_data/password.js', () => {
+  it('returns enabled:false and empty hash when PAGE_PASSWORD is not set', async () => {
+    delete process.env.PAGE_PASSWORD;
+    const { createRequire } = await import('node:module');
+    const require = createRequire(import.meta.url);
+    const modPath = resolve(ROOT, '_data/password.js');
+    delete require.cache[modPath];
+    const passwordData = require(modPath)();
+    assert.equal(passwordData.enabled, false);
+    assert.equal(passwordData.hash, '');
+  });
+
+  it('returns enabled:true and correct sha256 hash when PAGE_PASSWORD is set', async () => {
+    process.env.PAGE_PASSWORD = 'test-secret-42';
+    const { createRequire } = await import('node:module');
+    const require = createRequire(import.meta.url);
+    const modPath = resolve(ROOT, '_data/password.js');
+    delete require.cache[modPath];
+    const passwordData = require(modPath)();
+    assert.equal(passwordData.enabled, true);
+    assert.equal(passwordData.hash, sha256('test-secret-42'));
+    delete process.env.PAGE_PASSWORD;
+  });
+});


### PR DESCRIPTION
The protected route overlay now explains the project is under NDA and directs visitors to jonmccon@gmail.com for access.

Changes:
- _includes/layouts/base.njk: replace generic 'password protected' paragraph with h1 headline, NDA body copy, CTA text, and a prominent mailto link. Password input remains as a de-emphasized secondary affordance for those who already have the password.
- public/css/index.css: new NDA-specific classes (nda-headline, nda-body, nda-cta, nda-email-link, nda-password-form) using the site's headline/body font tokens and color variables. Password form opacity fades to 0.6 at rest, 1.0 on focus.
- package.json: add 'test' script (node --test)
- tests/nda-splash.test.js: 17 tests covering NDA overlay content, password form secondary affordance, hash logic (correct/wrong), session storage persistence, and _data/password.js module behavior