### PR TITLE
content: rewrite awake-chocolate as minor project

### DIFF
--- a/content/design/awake-chocolate/awake-chocolate.md
+++ b/content/design/awake-chocolate/awake-chocolate.md
@@ -1,14 +1,14 @@
 ---
 title: Awake Chocolate
-description: A compass to the caffeinated chocolate
+description: A store locator built from a custom Google Maps theme and a lot of geocoding
 category: Tether
 date: 2013-06-01
 draft: true
 thumbnail: /img/thumbnails/awake-thumb.png
 tags:
   - web
+  - mobile
   - branding
-  - illustration
 images: 
 - src: "content/design/awake-chocolate/awake-00.png"
 - src: "content/design/awake-chocolate/awake-01.png"
@@ -18,21 +18,23 @@ images:
 - src: "content/design/awake-chocolate/awake-05.png"
 ---
 
-Digital cartography platforms are notably difficult to theme visually due to the quantity of information presented and how it’s rendered. I asked myself just how far could I push Google Maps with a simple JSON styling tool and GPS locationing. Honestly that led to me pushing myself to the brink of copy & paste insanity when I needed to geocode all the gas stations across greater Ontario that carried these. 
+Awake Chocolate made caffeinated chocolate bars and needed a way to help people find them. I built a store locator — a simple enough idea that turned into a deep dive on Google Maps JSON theming and a lot of manual geocoding.
 
-https://mapstyle.withgoogle.com/
-https://www.dwzone-it.com/StyledMapWizard/StyledMapWizard.asp
+The design had to feel like the product: rich browns, warm leather textures, the brand's blocky type. Getting Google Maps to match that meant tuning every road, water, and label layer through the Styled Map Wizard until the map looked less like a utility and more like part of the interface. The desktop view, the mobile search, the results list, the directions screen — all of it had to hold together in one colour story.
 
+The harder part was the data. Awake was distributed across gas stations in Ontario at the time, and none of that was in a clean database. I geocoded the locations by hand, one by one, until the map had enough pins to be useful.
+
+Early career work, but it taught me that map-based UIs are almost entirely a data problem dressed up as a design problem.
 
 <div class="two-column">
 
-{% image "./awake-04.png", "Awake Chocolate project image" %}
+{% image "./awake-04.png", "Awake Chocolate mobile store locator landing screen" %}
 
-{% image "./awake-05.png", "Awake Chocolate project image" %}
+{% image "./awake-05.png", "Awake Chocolate mobile results list" %}
 
-{% image "./awake-02.png", "Awake Chocolate project image" %}
+{% image "./awake-02.png", "Awake Chocolate desktop store locator with map results" %}
 
-{% image "./awake-03.png", "Awake Chocolate project image" %}
+{% image "./awake-03.png", "Awake Chocolate desktop directions and flavors view" %}
 
 
 </div>

--- a/content/design/awake-chocolate/awake-chocolate.md
+++ b/content/design/awake-chocolate/awake-chocolate.md
@@ -5,7 +5,7 @@ description: A store locator built from a custom Google Maps theme and a lot of 
 category: Tether
 date: 2013-06-01
 permalink: /design/awake-chocolate/
-draft: true
+draft: false
 featured: false
 semiFeatured: false
 thumbnail: /img/thumbnails/awake-thumb.png

--- a/content/design/awake-chocolate/awake-chocolate.md
+++ b/content/design/awake-chocolate/awake-chocolate.md
@@ -1,5 +1,5 @@
 ---
-title: Awake Chocolate | Product Design | Jonny McConnell
+title: Awake Chocolate | Branding | Jonny McConnell
 pageHeadline: Awake Chocolate
 description: A store locator built from a custom Google Maps theme and a lot of geocoding
 category: Tether

--- a/content/design/awake-chocolate/awake-chocolate.md
+++ b/content/design/awake-chocolate/awake-chocolate.md
@@ -26,7 +26,11 @@ images:
 
 Awake Chocolate needed a store locator that felt like part of the brand, not a generic utility bolted onto the website.
 
-**Role:** Designer / front-end implementation · **Client:** Awake Chocolate · **Timeline:** 2013 · **Platform:** Responsive web store locator · **Status:** Early-career project, archived draft
+- **Role:** Designer / front-end implementation
+- **Client:** Awake Chocolate
+- **Timeline:** 2013
+- **Platform:** Responsive web store locator
+- **Status:** [Released](https://awakechocolate.com/pages/store-locator)
 
 Awake Chocolate made caffeinated chocolate bars and needed a way to help people find them in the real world. I designed and built a locator experience that worked across desktop and mobile, then pushed Google Maps styling much further than I expected to make it feel consistent with the rest of the site.
 

--- a/content/design/awake-chocolate/awake-chocolate.md
+++ b/content/design/awake-chocolate/awake-chocolate.md
@@ -1,9 +1,13 @@
 ---
-title: Awake Chocolate
+title: Awake Chocolate | Product Design | Jonny McConnell
+pageHeadline: Awake Chocolate
 description: A store locator built from a custom Google Maps theme and a lot of geocoding
 category: Tether
 date: 2013-06-01
+permalink: /design/awake-chocolate/
 draft: true
+featured: false
+semiFeatured: false
 thumbnail: /img/thumbnails/awake-thumb.png
 tags:
   - web
@@ -18,13 +22,25 @@ images:
 - src: "content/design/awake-chocolate/awake-05.png"
 ---
 
-Awake Chocolate made caffeinated chocolate bars and needed a way to help people find them. I built a store locator — a simple enough idea that turned into a deep dive on Google Maps JSON theming and a lot of manual geocoding.
+## The Brief
 
-The design had to feel like the product: rich browns, warm leather textures, the brand's blocky type. Getting Google Maps to match that meant tuning every road, water, and label layer through the Styled Map Wizard until the map looked less like a utility and more like part of the interface. The desktop view, the mobile search, the results list, the directions screen — all of it had to hold together in one colour story.
+Awake Chocolate needed a store locator that felt like part of the brand, not a generic utility bolted onto the website.
 
-The harder part was the data. Awake was distributed across gas stations in Ontario at the time, and none of that was in a clean database. I geocoded the locations by hand, one by one, until the map had enough pins to be useful.
+**Role:** Designer / front-end implementation · **Client:** Awake Chocolate · **Timeline:** 2013 · **Platform:** Responsive web store locator · **Status:** Early-career project, archived draft
 
-Early career work, but it taught me that map-based UIs are almost entirely a data problem dressed up as a design problem.
+Awake Chocolate made caffeinated chocolate bars and needed a way to help people find them in the real world. I designed and built a locator experience that worked across desktop and mobile, then pushed Google Maps styling much further than I expected to make it feel consistent with the rest of the site.
+
+## The Problem
+
+A store locator sounds straightforward until the map becomes the interface. The challenge was not just dropping pins on a default embed, it was making the experience feel like Awake. Rich browns, warm leather textures, and the brand's blocky type all had to carry through from the surrounding site into the search, results, and directions views.
+
+That meant tuning the Google Maps JSON theme layer by layer until the roads, water, and labels stopped fighting the interface and started supporting it.
+
+## The Constraint
+
+The harder part was the data. Awake was distributed across gas stations in Ontario at the time, and the locations were not sitting in a clean, ready-to-use dataset. I geocoded the stores by hand, one by one, until the locator had enough useful coverage to work as an actual customer tool instead of just a visual concept.
+
+That project left a lasting lesson: map-based products often look like a visual design challenge on the surface, but the real work is usually structure, coverage, and accuracy underneath.
 
 <div class="two-column">
 


### PR DESCRIPTION
## Summary

Rewrites the Awake Chocolate portfolio page from raw developer notes into a clean minor project entry.

## Changes
- Replaces bare URLs and technical notes-to-self with a focused narrative
- Leads with the actual problem (store locator), then the craft (Google Maps JSON theming + manual geocoding)
- Adds honest 'early career' framing as a closer
- Updates tags: adds `mobile`, removes `illustration`
- Improves image alt text with descriptive labels

## Preview
Draft page — `draft: true` flag unchanged, not publishing yet.