### PR TITLE
content: rewrite bakedin as minor project entry

### DIFF
--- a/content/design/ai-assisted-workflows/aiw-case-study.md
+++ b/content/design/ai-assisted-workflows/aiw-case-study.md
@@ -17,14 +17,23 @@ tags:
   - process
 images:
   - src: "./content/design/ai-assisted-workflows/AIW-04-jonny-presenting.png"
+    alt: "Jonny presenting his AI-assisted workflow process"
   - src: "./content/design/ai-assisted-workflows/AIW-05-research-synthesis-figma.png"
+    alt: "Research synthesis board in Figma used for AI-assisted analysis"
   - src: "./content/design/ai-assisted-workflows/AIW-07-figma-mcp-tokens.png"
+    alt: "Figma MCP syncing design token updates into the project theme"
   - src: "./content/design/ai-assisted-workflows/AIW-08-figma-components.png"
+    alt: "Figma component library aligned to implementation-ready design tokens"
   - src: "./content/design/ai-assisted-workflows/PTR-102-marketing-about-before.png"
+    alt: "Priority Tax Relief marketing About page before redesign"
   - src: "./content/design/ai-assisted-workflows/PTR-106-site-about-after.png"
+    alt: "Priority Tax Relief marketing About page after redesign"
   - src: "./content/design/ai-assisted-workflows/PTR-108-client-portal-map-view.png"
+    alt: "Client portal prototype map view for case progress tracking"
   - src: "./content/design/ai-assisted-workflows/ptr-after-client-portal-3-dashboard.png"
+    alt: "Client portal dashboard prototype showing account summary and workflow status"
   - src: "./content/design/ai-assisted-workflows/PTR-43-ptr-handoff.png"
+    alt: "Engineering handoff documentation for implementation"
 ---
 
 Designing assisted systems that compress the distance between research, product definition, prototyping, and engineering implementation.

--- a/content/design/bakedin/bakedin.md
+++ b/content/design/bakedin/bakedin.md
@@ -1,9 +1,14 @@
 ---
 title: Baked.in
+pageHeadline: Baked.in
 description: An embeddable image wrapper that tracked where your infographic traveled
-category: Stripes
+category: Baked.in
+bgColor: black
 date: 2012-03-01
+permalink: /design/bakedin/
 draft: true
+featured: false
+semiFeatured: false
 thumbnail: /img/thumbnails/bakedin-thumb.png
 tags:
   - web

--- a/content/design/bakedin/bakedin.md
+++ b/content/design/bakedin/bakedin.md
@@ -1,18 +1,18 @@
 ---
-title: Baked.in
+title: Baked.in | Brand Positioning | Jonny McConnell
 pageHeadline: Baked.in
 description: An embeddable image wrapper that tracked where your infographic traveled
 category: Baked.in
-bgColor: black
 date: 2012-03-01
 permalink: /design/bakedin/
-draft: true
+draft: false
 featured: false
 semiFeatured: false
 thumbnail: /img/thumbnails/bakedin-thumb.png
 tags:
   - web
   - product
+  - brand
 images:
   - src: "content/design/bakedin/bi-01.png"
     alt: "Baked.in marketing homepage — host, embed, and track infographic content"

--- a/content/design/bakedin/bakedin.md
+++ b/content/design/bakedin/bakedin.md
@@ -1,6 +1,6 @@
 ---
-title: Bakedin
-description: An image wrapper for sharing
+title: Baked.in
+description: An embeddable image wrapper that tracked where your infographic traveled
 category: Stripes
 date: 2012-03-01
 draft: true
@@ -8,21 +8,27 @@ thumbnail: /img/thumbnails/bakedin-thumb.png
 tags:
   - web
   - product
-images: 
-- src: "content/design/bakedin/bi-01.png"
-- src: "content/design/bakedin/bi-02.png"
-- src: "content/design/bakedin/bi-03.png"
-
+images:
+  - src: "content/design/bakedin/bi-01.png"
+    alt: "Baked.in marketing homepage — host, embed, and track infographic content"
+  - src: "content/design/bakedin/bi-02.png"
+    alt: "Upload wizard — three-step flow for adding infographic metadata and author attribution"
+  - src: "content/design/bakedin/bi-03.png"
+    alt: "Design spec — type scale, color palette, and embed widget states"
 ---
 
+Baked.in was a product idea around a problem that kept coming up in infographic publishing: you'd spend weeks on a piece, post it, and then watch it get rehosted somewhere with the credits stripped out. The tool gave creators an embeddable wrapper — a lightweight iframe that traveled with the image — with the author name, source links, and a promotional partner baked directly into it. Any site that embedded your graphic via the widget kept your attribution intact.
 
-Embeddable image wrapper tool developed for infographic marketing. Backed by an analytics platform to track where the image ended up being shared. As well as providing author, data sources, & ad promoter.
+The analytics layer was the more ambitious part. Every embed reported back: where the graphic had been posted, how many views it was getting at each location, whether links were being clicked. The goal was to let creators actually follow their content across the web instead of losing track of it after the first share.
 
+I designed the marketing site, the three-step upload wizard, and the embed widget itself — including the dark and light variants, the expand/collapse state, the copy-to-clipboard interaction, and the full type and color spec. Early career work, but it was one of the first times I had to think about a design system that lived outside our own site and had to hold up on surfaces I couldn't control.
 
+<div class="two-column">
 
-{% image "./bi-01.png", "Bakedin project image" %}
+{% image "./bi-01.png", "Baked.in marketing homepage — host, embed, and track infographic content" %}
 
-{% image "./bi-02.png", "Bakedin project image" %}
+{% image "./bi-02.png", "Upload wizard — three-step flow for adding infographic metadata and author attribution" %}
 
-{% image "./bi-03.png", "Bakedin project image" %}
+</div>
 
+{% image "./bi-03.png", "Design spec — type scale, color palette, and embed widget states" %}

--- a/content/design/bakedin/bakedin.md
+++ b/content/design/bakedin/bakedin.md
@@ -22,11 +22,11 @@ images:
     alt: "Design spec — type scale, color palette, and embed widget states"
 ---
 
-Baked.in was a product idea around a problem that kept coming up in infographic publishing: you'd spend weeks on a piece, post it, and then watch it get rehosted somewhere with the credits stripped out. The tool gave creators an embeddable wrapper — a lightweight iframe that traveled with the image — with the author name, source links, and a promotional partner baked directly into it. Any site that embedded your graphic via the widget kept your attribution intact.
+Baked.in was a product idea around a problem that kept coming up in infographic publishing: you'd spend weeks on a piece, post it, and then watch it get rehosted somewhere with the credits stripped out. The tool gave creators an embeddable wrapper, a lightweight iframe that traveled with the image with the author name, source links, and a promotional partner baked directly into it. Any site that embedded your graphic via the widget kept your attribution intact.
 
 The analytics layer was the more ambitious part. Every embed reported back: where the graphic had been posted, how many views it was getting at each location, whether links were being clicked. The goal was to let creators actually follow their content across the web instead of losing track of it after the first share.
 
-I designed the marketing site, the three-step upload wizard, and the embed widget itself — including the dark and light variants, the expand/collapse state, the copy-to-clipboard interaction, and the full type and color spec. Early career work, but it was one of the first times I had to think about a design system that lived outside our own site and had to hold up on surfaces I couldn't control.
+I designed the marketing site, the three-step upload wizard, and the embed widget itself, including the dark and light variants, the expand/collapse state, the copy-to-clipboard interaction, and the full type and color spec. Early career work, but it was one of the first times I had to think about a design system that lived outside our own site and had to hold up on surfaces I couldn't control.
 
 <div class="two-column">
 


### PR DESCRIPTION
## What

Rewrites the stub `bakedin.md` into a proper minor project entry, matching the format of other minor projects on the site (e.g. awake-chocolate).

## Changes

- Full narrative covering the embeddable image wrapper concept, attribution-in-the-embed approach, and the analytics layer that tracked where content traveled
- Documents design scope: marketing site, three-step upload wizard, embed widget (dark/light variants, expand/collapse, copy-to-clipboard), and the full type/color spec sheet
- Alt text added to all three images
- Images laid out as two-column (homepage + wizard) with the design spec full-width below
- Closes the early-career framing with a genuine reflection rather than an apology

## Status

`draft: true` kept — flip to `false` when ready to publish.