### PR TITLE
feat: Metastream portfolio copy rewrite

### DIFF
--- a/content/design/metastream/metastream.md
+++ b/content/design/metastream/metastream.md
@@ -38,9 +38,7 @@ images:
 - src: "./content/design/metastream/ms-130.png"
 ---
 
-The question Metastream tried to answer: what if the people around you right now — at this café, this park, this corner — could leave something for whoever came next?
-
-*Metastream sought to engage with the cohabitants of Seattle through an augmented reflection our environmental timeline. A map to see and understand surrounding realtime data and accessible only by being near a physical locale.* 
+Metastream sought to engage with the cohabitants of Seattle through an augmented reflection our environmental timeline. A map to see and understand surrounding realtime data and accessible only by being near a physical locale.
 
 - **Role:** Co-founder, UX / Product Design
 - **Collaborator:** Mike Shrieve (engineering, all browser implementations)
@@ -50,54 +48,116 @@ It was a location-locked social layer for Seattle. The map only showed you conte
 
 I co-founded the project with [Mike Shrieve](https://twitter.com/untelcombat), who built everything that ran in a browser: the React progressive web app, the Mapbox rendering pipeline, the Firebase real-time backend, user auth, geo-fenced queries, installable PWA on Android. I designed the product — user flows, the proximity model that determined what you could see, map interaction states, locale card layouts, how we'd handle unauthenticated users, when to ask for GPS permission, what happened when you deep-linked into a specific place.
 
-We went from a rough concept sketch pulling geolocated feeds onto a tilted 3D city map to a working, deployed PWA at [metastre.am](https://d.metastre.am/). We built a Sculpture Park installation-specific build. We ran it against live [OpenStreetMap](https://www.openstreetmap.org/) data and public [City of Seattle datasets](https://data.seattle.gov/). Six years of nights and weekends, learning things neither of us knew when we started — Node, Firebase, how to run a product together.
+We went from a rough concept sketch pulling geolocated feeds onto a tilted 3D city map to a working, deployed PWA at [metastre.am](https://d.metastre.am/). We built a Sculpture Park installation-specific build. We ran it against live [OpenStreetMap](https://www.openstreetmap.org/) data and public [City of Seattle datasets](https://data.seattle.gov/). Six years of nights and weekends, learning everything that neither of us knew when we started, especially how to run a product together.
 
-*We decided to stop before we shipped. Preserving the friendship was more important than crossing the finish line. That was the right decision — and six years of real work on a real product is the record regardless.*
+We built what we set out to do. Preserving the friendship was more important than crossing an ever moving finish line, so we decided to close the company. That was the right decision and six years of real work on a real product is the record regardless.
 
----
 
 <div class="three-column">
 
-{% image "./ms-20.png", "Metastream PWA — locale radius and map markers showing points of interest, built by Mike Shrieve" %}
+<figure>
+  {% image "./ms-20.png", "Metastream PWA — locale radius and map markers showing points of interest, built by Mike Shrieve" %}
+  <figcaption>Metastream PWA — locale radius and map markers showing points of interest, built by Mike Shrieve.</figcaption>
+</figure>
 
-{% image "./ms-21.png", "Metastream PWA — geo-fenced locale view with user post feed, built by Mike Shrieve" %}
+<figure>
+  {% image "./ms-21.png", "Metastream PWA — geo-fenced locale view with user post feed, built by Mike Shrieve" %}
+  <figcaption>Metastream PWA — geo-fenced locale view with user post feed, built by Mike Shrieve.</figcaption>
+</figure>
 
-{% image "./ms-23.png", "Metastream PWA — place detail with ratings and message thread, built by Mike Shrieve" %}
+<figure>
+  {% image "./ms-23.png", "Metastream PWA — place detail with ratings and message thread, built by Mike Shrieve" %}
+  <figcaption>Metastream PWA — place detail with ratings and message thread, built by Mike Shrieve.</figcaption>
+</figure>
 
 </div>
 
-{% image "./ms-24.png", "Architecture overview and prototype map layer with locale tabs — built by Mike Shrieve, system diagram drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-24.png", "Architecture overview and prototype map layer with locale tabs — built by Mike Shrieve, system diagram drawn by Jonny McConnell" %}
+  <figcaption>Architecture overview and prototype map layer with locale tabs — built by Mike Shrieve, system diagram drawn by Jonny McConnell.</figcaption>
+</figure>
 
-{% image "./ms-30.png", "Initial prototype with geolocated Twitter posts and OSM points of interest, neighborhood boundary overlays — built by Mike Shrieve" %}
+<figure>
+  {% image "./ms-30.png", "Initial prototype with geolocated Twitter posts and OSM points of interest, neighborhood boundary overlays — built by Mike Shrieve" %}
+  <figcaption>Initial prototype with geolocated Twitter posts and OSM points of interest, neighborhood boundary overlays — built by Mike Shrieve.</figcaption>
+</figure>
 
-{% image "./ms-35.png", "Twitter and OSM data study exploring non-north map orientation — built by Mike Shrieve" %}
+<figure>
+  {% image "./ms-35.png", "Twitter and OSM data study exploring non-north map orientation — built by Mike Shrieve" %}
+  <figcaption>Twitter and OSM data study exploring non-north map orientation — built by Mike Shrieve.</figcaption>
+</figure>
 
-{% image "./ms-40.png", "Locale querying based on user position — built by Mike Shrieve" %}
+<figure>
+  {% image "./ms-40.png", "Locale querying based on user position — built by Mike Shrieve" %}
+  <figcaption>Locale querying based on user position — built by Mike Shrieve.</figcaption>
+</figure>
 
-{% image "./ms-50.png", "Responsive web app with user login, user-generated messages attached to OSM shops, restaurants, and points of interest — built by Mike Shrieve" %}
+<figure>
+  {% image "./ms-50.png", "Responsive web app with user login, user-generated messages attached to OSM shops, restaurants, and points of interest — built by Mike Shrieve" %}
+  <figcaption>Responsive web app with user login, user-generated messages attached to OSM shops, restaurants, and points of interest — built by Mike Shrieve.</figcaption>
+</figure>
 
-{% image "./ms-60.png", "Mapbox visual study in map projection (left) drawn by Jonny McConnell; messaging prototype for users at a locale (right) built by Mike Shrieve" %}
+<figure>
+  {% image "./ms-60.png", "Mapbox visual study in map projection (left) drawn by Jonny McConnell; messaging prototype for users at a locale (right) built by Mike Shrieve" %}
+  <figcaption>Mapbox visual study in map projection (left) drawn by Jonny McConnell; messaging prototype for users at a locale (right) built by Mike Shrieve.</figcaption>
+</figure>
 
-{% image "./ms-70.png", "Sculpture Park installation build — Metastream PWA installed on mobile phone, location-specific content active — built by Mike Shrieve" %}
+<figure>
+  {% image "./ms-70.png", "Sculpture Park installation build — Metastream PWA installed on mobile phone, location-specific content active — built by Mike Shrieve" %}
+  <figcaption>Sculpture Park installation build — Metastream PWA installed on mobile phone, location-specific content active — built by Mike Shrieve.</figcaption>
+</figure>
 
-{% image "./ms-75.png", "Installation-specific content with attached user messages — built by Mike Shrieve" %}
+<figure>
+  {% image "./ms-75.png", "Installation-specific content with attached user messages — built by Mike Shrieve" %}
+  <figcaption>Installation-specific content with attached user messages — built by Mike Shrieve.</figcaption>
+</figure>
 
-{% image "./ms-80.png", "User flow diagrams — drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-80.png", "User flow diagrams — drawn by Jonny McConnell" %}
+  <figcaption>User flow diagrams — drawn by Jonny McConnell.</figcaption>
+</figure>
 
-{% image "./ms-85.png", "User flow diagrams — drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-85.png", "User flow diagrams — drawn by Jonny McConnell" %}
+  <figcaption>User flow diagrams — drawn by Jonny McConnell.</figcaption>
+</figure>
 
-{% image "./ms-86.png", "User flow diagrams — drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-86.png", "User flow diagrams — drawn by Jonny McConnell" %}
+  <figcaption>User flow diagrams — drawn by Jonny McConnell.</figcaption>
+</figure>
 
-{% image "./ms-90.png", "Map interaction and messaging studies — drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-90.png", "Map interaction and messaging studies — drawn by Jonny McConnell" %}
+  <figcaption>Map interaction and messaging studies — drawn by Jonny McConnell.</figcaption>
+</figure>
 
-{% image "./ms-95.png", "Map interaction and messaging studies — drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-95.png", "Map interaction and messaging studies — drawn by Jonny McConnell" %}
+  <figcaption>Map interaction and messaging studies — drawn by Jonny McConnell.</figcaption>
+</figure>
 
-{% image "./ms-100.png", "Pattern and visual hierarchy studies — drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-100.png", "Pattern and visual hierarchy studies — drawn by Jonny McConnell" %}
+  <figcaption>Pattern and visual hierarchy studies — drawn by Jonny McConnell.</figcaption>
+</figure>
 
-{% image "./ms-110.png", "Data analysis and content structure diagram — drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-110.png", "Data analysis and content structure diagram — drawn by Jonny McConnell" %}
+  <figcaption>Data analysis and content structure diagram — drawn by Jonny McConnell.</figcaption>
+</figure>
 
-{% image "./ms-120.png", "Original concept: geolocated social feed posts layered on a 3D city map — drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-120.png", "Original concept: geolocated social feed posts layered on a 3D city map — drawn by Jonny McConnell" %}
+  <figcaption>Original concept: geolocated social feed posts layered on a 3D city map — drawn by Jonny McConnell.</figcaption>
+</figure>
 
-{% image "./ms-125.png", "Original concept: real-time location feedback mechanism — drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-125.png", "Original concept: real-time location feedback mechanism — drawn by Jonny McConnell" %}
+  <figcaption>Original concept: real-time location feedback mechanism — drawn by Jonny McConnell.</figcaption>
+</figure>
 
-{% image "./ms-130.png", "Concept exploration drawing from Normal Future — drawn by Jonny McConnell" %}
+<figure>
+  {% image "./ms-130.png", "Concept exploration drawing from Normal Future — drawn by Jonny McConnell" %}
+  <figcaption>Concept exploration drawing from Normal Future — drawn by Jonny McConnell.</figcaption>
+</figure>

--- a/content/design/metastream/metastream.md
+++ b/content/design/metastream/metastream.md
@@ -1,9 +1,13 @@
 ---
-title: Metastream
-description: A location-locked social layer for Seattle — content unlocked by physical presence, built as a PWA over six years with co-founder Mike Shrieve.
+title: Metastream | Product Designer | Jonny McConnell
+pageHeadline: Metastream Location Chat
+description: A location-locked social layer for Seattle, content unlocked by physical presence, built as a PWA over six years with co-founder Mike Shrieve.
 category: Metastream
 date: 2019-08-01
+permalink: /design/metastream-location-chat/
 draft: true
+featured: true
+semiFeatured: true
 thumbnail: /img/thumbnails/metastream-thumb.png
 tags:
   - ux
@@ -34,11 +38,13 @@ images:
 - src: "./content/design/metastream/ms-130.png"
 ---
 
-**Role:** Co-founder, UX / Product Design
-**Collaborator:** Mike Shrieve (engineering, all browser implementations)
-**Built on:** React PWA · Mapbox · Firebase · Google Cloud Platform · OpenStreetMap · Node.js · GitLab
-
 The question Metastream tried to answer: what if the people around you right now — at this café, this park, this corner — could leave something for whoever came next?
+
+*Metastream sought to engage with the cohabitants of Seattle through an augmented reflection our environmental timeline. A map to see and understand surrounding realtime data and accessible only by being near a physical locale.* 
+
+- **Role:** Co-founder, UX / Product Design
+- **Collaborator:** Mike Shrieve (engineering, all browser implementations)
+- **Built on:** React PWA · Mapbox · Firebase · Google Cloud Platform · OpenStreetMap · Node.js · GitLab
 
 It was a location-locked social layer for Seattle. The map only showed you content from your immediate area, unlocked by physical presence. Tap a locale marker and you'd see its rating, the messages people had left, and who else had been there. Leave a post of your own. Come back tomorrow and it would have grown.
 
@@ -46,7 +52,7 @@ I co-founded the project with [Mike Shrieve](https://twitter.com/untelcombat), w
 
 We went from a rough concept sketch pulling geolocated feeds onto a tilted 3D city map to a working, deployed PWA at [metastre.am](https://d.metastre.am/). We built a Sculpture Park installation-specific build. We ran it against live [OpenStreetMap](https://www.openstreetmap.org/) data and public [City of Seattle datasets](https://data.seattle.gov/). Six years of nights and weekends, learning things neither of us knew when we started — Node, Firebase, how to run a product together.
 
-We decided to stop before we shipped. Preserving the friendship was more important than crossing the finish line. That was the right decision — and six years of real work on a real product is the record regardless.
+*We decided to stop before we shipped. Preserving the friendship was more important than crossing the finish line. That was the right decision — and six years of real work on a real product is the record regardless.*
 
 ---
 

--- a/content/design/metastream/metastream.md
+++ b/content/design/metastream/metastream.md
@@ -5,7 +5,7 @@ description: A location-locked social layer for Seattle, content unlocked by phy
 category: Metastream
 date: 2019-08-01
 permalink: /design/metastream-location-chat/
-draft: true
+draft: false
 featured: true
 semiFeatured: true
 thumbnail: /img/thumbnails/metastream-thumb.png

--- a/content/design/metastream/metastream.md
+++ b/content/design/metastream/metastream.md
@@ -1,6 +1,6 @@
 ---
 title: Metastream
-description: Rich Location Based Media 
+description: A location-locked social layer for Seattle — content unlocked by physical presence, built as a PWA over six years with co-founder Mike Shrieve.
 category: Metastream
 date: 2019-08-01
 draft: true
@@ -9,7 +9,8 @@ tags:
   - ux
   - product
   - mobile
-images: 
+  - web
+images:
 - src: "./content/design/metastream/ms-20.png"
 - src: "./content/design/metastream/ms-21.png"
 - src: "./content/design/metastream/ms-23.png"
@@ -33,94 +34,64 @@ images:
 - src: "./content/design/metastream/ms-130.png"
 ---
 
-[] anchor to imags?
+**Role:** Co-founder, UX / Product Design
+**Collaborator:** Mike Shrieve (engineering, all browser implementations)
+**Built on:** React PWA · Mapbox · Firebase · Google Cloud Platform · OpenStreetMap · Node.js · GitLab
 
-Strengthening our spatial citizenship
-A minimap for good locales
+The question Metastream tried to answer: what if the people around you right now — at this café, this park, this corner — could leave something for whoever came next?
 
-Metastream sought to engage with the cohabitants of Seattle through an augmented reflection our environmental timeline. A map to see and understand surrounding realtime data and accessible only by being near a physical locale. 
--
-In collaboration with cofounder Mike Shrieve, a study that leveraged Node / React as a progressive webapp, Mapbox, Firebase, Google Cloud platform, and Gitlab. In collaboration with the Open Streetmap community and public data from the City of Seattle. 
--
-Unreleased
--
+It was a location-locked social layer for Seattle. The map only showed you content from your immediate area, unlocked by physical presence. Tap a locale marker and you'd see its rating, the messages people had left, and who else had been there. Leave a post of your own. Come back tomorrow and it would have grown.
 
-Metastream sought to engage with the cohabitants of Seattle through an augmented reflection our environmental timeline. A map to see and understand surrounding realtime data and accessible only by being near a physical locale.
+I co-founded the project with [Mike Shrieve](https://twitter.com/untelcombat), who built everything that ran in a browser: the React progressive web app, the Mapbox rendering pipeline, the Firebase real-time backend, user auth, geo-fenced queries, installable PWA on Android. I designed the product — user flows, the proximity model that determined what you could see, map interaction states, locale card layouts, how we'd handle unauthenticated users, when to ask for GPS permission, what happened when you deep-linked into a specific place.
 
-In collaboration with cofounder Mike Shrieve, a study that leveraged (and required us to learn) progressive web apps, Mapbox, Firebase, Google Cloud platform, and Gitlab. In collaboration with the Open Streetmap community and public data from the City of Seattle.
+We went from a rough concept sketch pulling geolocated feeds onto a tilted 3D city map to a working, deployed PWA at [metastre.am](https://d.metastre.am/). We built a Sculpture Park installation-specific build. We ran it against live [OpenStreetMap](https://www.openstreetmap.org/) data and public [City of Seattle datasets](https://data.seattle.gov/). Six years of nights and weekends, learning things neither of us knew when we started — Node, Firebase, how to run a product together.
 
-Mobile / Desktop demo
-
-All images in browser windows built by Mike Shrieve
-
-
-https://twitter.com/untelcombat
-https://www.openstreetmap.org/
-https://data.seattle.gov/
-https://d.metastre.am/
-
+We decided to stop before we shipped. Preserving the friendship was more important than crossing the finish line. That was the right decision — and six years of real work on a real product is the record regardless.
 
 ---
 
 <div class="three-column">
 
-{% image "./ms-20.png", "Progressive web app prototype / built by Mike Shrieve" %}
-Progressive web app prototype / built by Mike Shrieve
+{% image "./ms-20.png", "Metastream PWA — locale radius and map markers showing points of interest, built by Mike Shrieve" %}
 
-{% image "./ms-21.png", "Progressive web app prototype / built by Mike Shrieve" %}
+{% image "./ms-21.png", "Metastream PWA — geo-fenced locale view with user post feed, built by Mike Shrieve" %}
 
-{% image "./ms-23.png", "Progressive web app prototype / built by Mike Shrieve" %}
+{% image "./ms-23.png", "Metastream PWA — place detail with ratings and message thread, built by Mike Shrieve" %}
 
 </div>
 
-{% image "./ms-24.png", "(left) Combo prototype map layer & location tabs with (right) architecture breakdown / built by Mike Shrieve & drawn by Jonny McConnell" %}
-(left) Combo prototype map layer & location tabs with (right) architecture breakdown / built by Mike Shrieve & drawn by Jonny McConnell
+{% image "./ms-24.png", "Architecture overview and prototype map layer with locale tabs — built by Mike Shrieve, system diagram drawn by Jonny McConnell" %}
 
-{% image "./ms-30.png", "Initial prototype with geolocated Twitter posts & OSM points of interest along with neighborhood distinctions / built by Mike Shrieve" %}
-Initial prototype with geolocated Twitter posts & OSM points of interest along with neighborhood distinctions / built by Mike Shrieve
+{% image "./ms-30.png", "Initial prototype with geolocated Twitter posts and OSM points of interest, neighborhood boundary overlays — built by Mike Shrieve" %}
 
-{% image "./ms-35.png", "Additional Twitter + OSM data study looking at non north map orientation / built by Mike Shrieve" %}
-Additional Twitter + OSM data study looking at non north map orientation / built by Mike Shrieve
+{% image "./ms-35.png", "Twitter and OSM data study exploring non-north map orientation — built by Mike Shrieve" %}
 
-{% image "./ms-40.png", "Locale querying based on user position / built by Mike Shrieve" %}
-Locale querying based on user position / built by Mike Shrieve
+{% image "./ms-40.png", "Locale querying based on user position — built by Mike Shrieve" %}
 
-{% image "./ms-50.png", "Responsive web app with user login, user generated messages attached to OSM shops, restaurants, and points of interest / built by Mike Shrieve" %}
-Responsive web app with user login, user generated messages attached to OSM shops, restaurants, and points of interest / built by Mike Shrieve
+{% image "./ms-50.png", "Responsive web app with user login, user-generated messages attached to OSM shops, restaurants, and points of interest — built by Mike Shrieve" %}
 
-{% image "./ms-60.png", "(left) Mapbox visual study in map projection / built by Jonny McConnell (right) messaging prototype for users at a locale / built by Mike Shrieve" %}
-(left) Mapbox visual study in map projection / built by Jonny McConnell (right) messaging prototype for users at a locale / built by Mike Shrieve
+{% image "./ms-60.png", "Mapbox visual study in map projection (left) drawn by Jonny McConnell; messaging prototype for users at a locale (right) built by Mike Shrieve" %}
 
-{% image "./ms-70.png", "Sculpture Park specific iteration of metastream system and PWA installation on mobile phone / built by Mike Shrieve" %}
-Sculpture Park specific iteration of metastream system and PWA installation on mobile phone / built by Mike Shrieve
+{% image "./ms-70.png", "Sculpture Park installation build — Metastream PWA installed on mobile phone, location-specific content active — built by Mike Shrieve" %}
 
-{% image "./ms-75.png", "Installation specific content and attached user messages / built by Mike Shrieve" %}
-Installation specific content and attached user messages / built by Mike Shrieve
+{% image "./ms-75.png", "Installation-specific content with attached user messages — built by Mike Shrieve" %}
 
-{% image "./ms-80.png", "User flow diagrams / drawn by Jonny McConnell" %}
+{% image "./ms-80.png", "User flow diagrams — drawn by Jonny McConnell" %}
 
-{% image "./ms-85.png", "User flow diagrams / drawn by Jonny McConnell" %}
+{% image "./ms-85.png", "User flow diagrams — drawn by Jonny McConnell" %}
 
-{% image "./ms-86.png", "User flow diagrams / drawn by Jonny McConnell" %}
-User flow diagrams / drawn by Jonny McConnell
+{% image "./ms-86.png", "User flow diagrams — drawn by Jonny McConnell" %}
 
-{% image "./ms-90.png", "Map and messaging studies / drawn by Jonny McConnell" %}
-Map and messaging studies / drawn by Jonny McConnell
+{% image "./ms-90.png", "Map interaction and messaging studies — drawn by Jonny McConnell" %}
 
-{% image "./ms-95.png", "Map and messaging studies / drawn by Jonny McConnell" %}
-Map and messaging studies / drawn by Jonny McConnell
+{% image "./ms-95.png", "Map interaction and messaging studies — drawn by Jonny McConnell" %}
 
-{% image "./ms-100.png", "Pattern and visibility studies / drawn by Jonny McConnell" %}
-Pattern and visibility studies / drawn by Jonny McConnell
+{% image "./ms-100.png", "Pattern and visual hierarchy studies — drawn by Jonny McConnell" %}
 
-{% image "./ms-110.png", "Data analysis structure / drawn by Jonny McConnell" %}
-Data analysis structure / drawn by Jonny McConnell
+{% image "./ms-110.png", "Data analysis and content structure diagram — drawn by Jonny McConnell" %}
 
-{% image "./ms-120.png", "Original concept layout of posts on a map / drawn by Jonny McConnell" %}
-Original concept layout of posts on a map / drawn by Jonny McConnell
+{% image "./ms-120.png", "Original concept: geolocated social feed posts layered on a 3D city map — drawn by Jonny McConnell" %}
 
-{% image "./ms-125.png", "Original concept layout of a realtime location feedback mechanism / drawn by Jonny McConnell" %}
-Original concept layout of a realtime location feedback mechanism / drawn by Jonny McConnell
+{% image "./ms-125.png", "Original concept: real-time location feedback mechanism — drawn by Jonny McConnell" %}
 
-{% image "./ms-130.png", "Inspiration from the work of Normal Future / drawn by Jonny McConnell" %}
-Inspiration from the work of Normal Future / drawn by Jonny McConnell
+{% image "./ms-130.png", "Concept exploration drawing from Normal Future — drawn by Jonny McConnell" %}


### PR DESCRIPTION
## What changed

Full narrative rewrite of the Metastream project page — the co-founded startup, six years of nights and weekends.

### Copy changes
- **Frontmatter:** expanded `description` to a proper one-liner; added `web` tag
- **New credits block:** explicit Role / Collaborator / Stack header
- **Lead paragraph:** problem-first framing (the product question, not the tech)
- **Body narrative:** named collaboration model (Mike built the browser stack; Jonny designed the product), specific milestones (deployed PWA at metastre.am, Sculpture Park install, live OSM + Seattle open data)
- **Closer:** honest — six years, stopped before shipping, friendship over finish line

### Cleanup
- Replaced generic/duplicate alt text with per-image descriptions of actual content
- Stripped bare URLs from body copy
- Stripped stray `-` paragraph breaks that render as `<hr>` in Eleventy
- Removed duplicate body paragraphs (the file had the same text twice)